### PR TITLE
feat: add sar_player_trace

### DIFF
--- a/src/Features.hpp
+++ b/src/Features.hpp
@@ -34,3 +34,4 @@
 #include "Features/SegmentedTools.hpp"
 #include "Features/GroundFramesCounter.hpp"
 #include "Features/Hud/Toasts.hpp"
+#include "Features/PlayerTrace.hpp"

--- a/src/Features/PlayerTrace.cpp
+++ b/src/Features/PlayerTrace.cpp
@@ -1,0 +1,164 @@
+#include "PlayerTrace.hpp"
+
+#include <vector>
+
+#include "Modules/Console.hpp"
+#include "Modules/Engine.hpp"
+#include "Modules/Server.hpp"
+#include "Modules/Client.hpp"
+
+#include "Features/GroundFramesCounter.hpp"
+
+#include "Command.hpp"
+#include "Event.hpp"
+
+PlayerTrace* playerTrace;
+
+#ifdef _WIN32
+#define ADD_LINE_OVERLAY(...) engine->AddLineOverlay(__VA_ARGS__)
+#else
+#define ADD_LINE_OVERLAY(...) engine->AddLineOverlay(nullptr, __VA_ARGS__)
+#endif
+
+Variable sar_player_trace_draw("sar_player_trace_draw", "0", "Display the recorded player trace\n");
+Variable sar_player_trace_record("sar_player_trace_record", "0", "Record player trace while set to 1\n");
+Variable sar_player_trace_size("sar_player_trace_size", "0", 0, "Maximum size of the player trace (in ticks), 0 for unlimited\n");
+
+PlayerTrace::PlayerTrace()
+{
+    this->hasLoaded = true;
+}
+void PlayerTrace::AddPoint(const Vector point)
+{
+    if (sar_player_trace_size.GetInt() && (trace.size() > sar_player_trace_size.GetInt())) {
+        trace.erase(trace.begin());
+        for (size_t &groundframe: groundframes) {
+            groundframe--;
+        }
+        if (groundframes[0] == -1)
+            groundframes.erase(groundframes.begin());
+    }
+
+    trace.push_back(point);
+}
+void PlayerTrace::Clear()
+{
+    this->trace.clear();
+    this->groundframes.clear();
+}
+void PlayerTrace::AddGroundFrame() {
+    this->groundframes.push_back(trace.size());
+}
+void PlayerTrace::DrawInWorld(float time) const
+{
+    int r, g, b;
+    size_t groundframes_idx = 0;
+
+    if (trace.size() == 0) return;
+    for (size_t i = 0; i < trace.size()-1; i++) {
+
+        if (groundframes_idx < groundframes.size() && groundframes[groundframes_idx] == i) {
+            groundframes_idx++;
+            r = 255; g = 0; b = 0;
+        } else {
+            r = 255; g = 255; b = 255;
+        }
+
+        ADD_LINE_OVERLAY(
+            trace[i], trace[i+1],
+            r, g, b,
+            true,
+            time
+        );
+    }
+}
+void PlayerTrace::DrawSpeedDeltas(HudContext *ctx) const
+{
+    if (groundframes.size() == 0) return;
+
+    int hud_id = 10;
+
+    size_t first_groundframe_tick = 0;
+    size_t last_groundframe_tick = 0;
+    size_t idx_offset = 2; // To account for alt ticks
+
+    // We're only interested in the places where we change grounded state
+    for (size_t i = 0; i < groundframes.size(); i++) {
+        if (groundframes[i] == last_groundframe_tick + 1) {
+            last_groundframe_tick++;
+        } else {
+            const Vector hud_offset = {0.0, 0.0, 10.0};
+            Vector screen_pos;
+            Vector speed_a, speed_b;
+            float speed_delta;
+
+            if (first_groundframe_tick == 0) first_groundframe_tick += idx_offset;
+            if (first_groundframe_tick != last_groundframe_tick) {
+                // Display speed delta between first and last groundframe
+                speed_a = (trace[first_groundframe_tick - idx_offset] - trace[first_groundframe_tick])/idx_offset;
+                speed_b = (trace[last_groundframe_tick - idx_offset] - trace[last_groundframe_tick])/idx_offset;
+                speed_delta = sqrt(speed_b.x*speed_b.x + speed_b.y*speed_b.y) - sqrt(speed_a.x*speed_a.x + speed_a.y*speed_a.y);
+
+                engine->PointToScreen(trace[first_groundframe_tick + (last_groundframe_tick - first_groundframe_tick)/2] + hud_offset, screen_pos);
+                ctx->DrawElementOnScreen(hud_id++, screen_pos.x, screen_pos.y, "%10.2f", speed_delta * 60);
+            }
+            // Display speed delta between last groundframe and current tick
+            // aka speed delta for the current hop
+            speed_a = (trace[last_groundframe_tick - idx_offset] - trace[last_groundframe_tick])/idx_offset;
+            speed_b = (trace[groundframes[i] - idx_offset] - trace[groundframes[i]])/idx_offset;
+            speed_delta = sqrt(speed_b.x*speed_b.x + speed_b.y*speed_b.y) - sqrt(speed_a.x*speed_a.x + speed_a.y*speed_a.y);
+
+            engine->PointToScreen(trace[last_groundframe_tick + (groundframes[i] - last_groundframe_tick)/2] + hud_offset, screen_pos);
+            ctx->DrawElementOnScreen(hud_id++, screen_pos.x, screen_pos.y, "%10.2f", speed_delta * 60);
+
+            first_groundframe_tick = groundframes[i];
+            last_groundframe_tick = groundframes[i];
+        }
+    }
+}
+
+ON_EVENT(PRE_TICK) {
+
+    // Record trace
+    if (sar_player_trace_record.GetBool() && !engine->IsGamePaused()) {
+        auto nSlot = GET_SLOT();
+        auto player = client->GetPlayer(nSlot + 1);
+        if (player) {
+            playerTrace->AddPoint(client->GetAbsOrigin(player));
+            if (groundFramesCounter->grounded[nSlot]) {
+                playerTrace->AddGroundFrame();
+            }
+        }
+    }
+
+    // Draw trace
+    const int drawDelta = 30;
+    static int lastDrawTick = -1000;
+
+    if (!sar_player_trace_draw.GetBool()) return;
+    if (!sv_cheats.GetBool()) return;
+
+    int tick = engine->GetTick();
+    if (tick > lastDrawTick && tick < lastDrawTick + drawDelta) return;
+
+    lastDrawTick = tick;
+    
+    playerTrace->DrawInWorld((drawDelta + 1) * *engine->interval_per_tick);
+}
+
+ON_EVENT(SESSION_START) {
+    playerTrace->Clear();
+}
+
+HUD_ELEMENT2(player_trace_draw_speed, "1", "Toggles drawing the speed deltas on the player traces\n", HudType_InGame) {
+
+    if (!sar_player_trace_draw.GetBool()) return;
+    if (!sv_cheats.GetBool()) return;
+
+    playerTrace->DrawSpeedDeltas(ctx);
+
+}
+
+CON_COMMAND(sar_player_trace_clear, "sar_player_trace_clear - Clear the recorded player trace\n") {
+    playerTrace->Clear();
+}

--- a/src/Features/PlayerTrace.hpp
+++ b/src/Features/PlayerTrace.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Feature.hpp"
+#include "Utils.hpp"
+#include "Features/Hud/Hud.hpp"
+
+class PlayerTrace : public Feature {
+private:
+    std::vector<Vector> trace;
+    // Records at which indexes into the trace the player was grounded
+    std::vector<size_t> groundframes;
+
+public:
+    PlayerTrace();
+    // Add a point to the player trace
+    void AddPoint(const Vector Point);
+    // Clear all the points
+    void Clear();
+    // Add a groundframe to the groundframe list
+    void AddGroundFrame();
+    // Display the trace in the world
+    void DrawInWorld(float time) const;
+    // Display XY-speed delta overlay
+    void DrawSpeedDeltas(HudContext *ctx) const;
+};
+
+extern PlayerTrace* playerTrace;

--- a/src/SAR.cpp
+++ b/src/SAR.cpp
@@ -88,6 +88,7 @@ bool SAR::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceFn gameServerF
             this->features->AddFeature<Camera>(&camera);
             this->features->AddFeature<GroundFramesCounter>(&groundFramesCounter);
             this->features->AddFeature<TimescaleDetect>(&timescaleDetect);
+            this->features->AddFeature<PlayerTrace>(&playerTrace);
             toastHud.InitMessageHandler();
 
             this->modules->AddModule<InputSystem>(&inputSystem);

--- a/src/SourceAutoRecord.vcxproj
+++ b/src/SourceAutoRecord.vcxproj
@@ -165,6 +165,7 @@
     <ClCompile Include="Features\Imitator.cpp" />
     <ClCompile Include="Features\Listener.cpp" />
     <ClCompile Include="Features\OffsetFinder.cpp" />
+    <ClCompile Include="Features\PlayerTrace.cpp" />
     <ClCompile Include="Features\Rebinder.cpp" />
     <ClCompile Include="Features\Routing\EntityInspector.cpp" />
     <ClCompile Include="Features\Routing\SeamshotFind.cpp" />
@@ -334,6 +335,7 @@
     <ClInclude Include="Features\Imitator.hpp" />
     <ClInclude Include="Features\Listener.hpp" />
     <ClInclude Include="Features\OffsetFinder.hpp" />
+    <ClInclude Include="Features\PlayerTrace.hpp" />
     <ClInclude Include="Features\Rebinder.hpp" />
     <ClInclude Include="Features\Routing\EntityInspector.hpp" />
     <ClInclude Include="Features\Routing\SeamshotFind.hpp" />

--- a/src/SourceAutoRecord.vcxproj.filters
+++ b/src/SourceAutoRecord.vcxproj.filters
@@ -169,6 +169,10 @@
     <ClCompile Include="Features\Listener.cpp">
       <Filter>SourceAutoRecord\Features</Filter>
     </ClCompile>
+  </ClCompile>
+  <ClCompile Include="Features\PlayerTrace.cpp">
+    <Filter>SourceAutoRecord\Features</Filter>
+  </ClCompile>
     <ClCompile Include="Features\Rebinder.cpp">
       <Filter>SourceAutoRecord\Features</Filter>
     </ClCompile>
@@ -643,6 +647,9 @@
       <Filter>SourceAutoRecord\Features</Filter>
     </ClInclude>
     <ClInclude Include="Features\Camera.hpp">
+      <Filter>SourceAutoRecord\Features</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\PlayerTrace.hpp">
       <Filter>SourceAutoRecord\Features</Filter>
     </ClInclude>
     <ClInclude Include="Features\Stats\StatsCounter.hpp">


### PR DESCRIPTION
Adds functionality do record the player path and groundframes, as well as display it back for analysis.