### PR TITLE
fix: improve TAS autostrafer

### DIFF
--- a/src/Features/Tas/TasTools/StrafeTool.cpp
+++ b/src/Features/Tas/TasTools/StrafeTool.cpp
@@ -195,7 +195,8 @@ float AutoStrafeTool::GetFastestStrafeAngle(const TasPlayerInfo &player) {
 	float maxSpeed = GetMaxSpeed(player, wishDir);
 	float maxAccel = GetMaxAccel(player, wishDir);
 
-	//finding the most optimal angle
+	// finding the most optimal angle. 
+	// formula shamelessly taken from https://www.jwchong.com/hl/movement.html
 	float cosAng = (maxSpeed - maxAccel) / velocity.Length2D();
 
 	if (cosAng < 0) cosAng = M_PI_F / 2;
@@ -215,8 +216,11 @@ float AutoStrafeTool::GetTargetStrafeAngle(const TasPlayerInfo &player, float ta
 	float maxSpeed = GetMaxSpeed(player, wishDir);
 	float maxAccel = GetMaxAccel(player, wishDir);
 
+	// Assuming that it is possible to achieve a velocity of a given length,
+	// I'm using a law of cosines to get the right angle for acceleration.
 	float cosAng = (pow(vel.Length2D(), 2) + pow(maxAccel, 2) - pow(targetSpeed, 2)) / (2.0f * vel.Length2D() * maxAccel);
 
+	// Also, questionable trig to get the right angle lol.
 	return acosf(-cosAng);
 }
 
@@ -228,9 +232,13 @@ float AutoStrafeTool::GetTurningStrafeAngle(const TasPlayerInfo &player) {
 	if (velocity.Length2D() == 0) return 0;
 
 	Vector wishDir(0, 1);
-	float maxSpeed = GetMaxSpeed(player, wishDir);
 	float maxAccel = GetMaxAccel(player, wishDir);
 
+	// In order to maximize the angle between old and new velocity, the angle between
+	// acceleration vector and new velocity must be 90 degrees, meaning that I can
+	// easily calculate the desired angle using simple cosine formula. The angle from 
+	// old velocity to acceleration (which is what we actually want to return) is simply 
+	// 90 degrees larger, so I'm doing some questionable trig math here to achieve this lol.
 	float cosAng = -maxAccel / velocity.Length2D();
 	if (cosAng < -1) cosAng = 0;
 

--- a/src/SourceAutoRecord.vcxproj
+++ b/src/SourceAutoRecord.vcxproj
@@ -186,6 +186,8 @@
     <ClCompile Include="Features\Stats\VelocityStats.cpp" />
     <ClCompile Include="Features\StepCounter.cpp" />
     <ClCompile Include="Features\Summary.cpp" />
+    <ClCompile Include="Features\Tas\TasTools\AutoAimTool.cpp" />
+    <ClCompile Include="Features\Tas\TasTools\SetAngleTool.cpp" />
     <ClCompile Include="Features\Updater.cpp" />
     <ClCompile Include="Features\ReplaySystem\Replay.cpp" />
     <ClCompile Include="Features\ReplaySystem\ReplayPlayer.cpp" />
@@ -362,6 +364,8 @@
     <ClInclude Include="Features\Stats\VelocityStats.hpp" />
     <ClInclude Include="Features\StepCounter.hpp" />
     <ClInclude Include="Features\Summary.hpp" />
+    <ClInclude Include="Features\Tas\TasTools\AutoAimTool.hpp" />
+    <ClInclude Include="Features\Tas\TasTools\SetAngleTool.hpp" />
     <ClInclude Include="Features\Updater.hpp" />
     <ClInclude Include="Features\ReplaySystem\Replay.hpp" />
     <ClInclude Include="Features\ReplaySystem\ReplayFrame.hpp" />

--- a/src/SourceAutoRecord.vcxproj.filters
+++ b/src/SourceAutoRecord.vcxproj.filters
@@ -370,9 +370,6 @@
     <ClCompile Include="Features\Camera.cpp">
       <Filter>SourceAutoRecord\Features</Filter>
     </ClCompile>
-    <ClCompile Include="Features\ConditionalExec.cpp">
-      <Filter>SourceAutoRecord\Features</Filter>
-    </ClCompile>
     <ClCompile Include="Features\Stats\StatsCounter.cpp">
       <Filter>SourceAutoRecord\Features\Stats</Filter>
     </ClCompile>
@@ -416,6 +413,9 @@
       <Filter>SourceAutoRecord\Features</Filter>
     </ClCompile>
     <ClCompile Include="Features\Tas\TasTools\AutoAimTool.cpp">
+      <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\Tas\TasTools\SetAngleTool.cpp">
       <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
     </ClCompile>
   </ItemGroup>
@@ -918,9 +918,6 @@
     <ClInclude Include="Features\Camera.hpp">
       <Filter>SourceAutoRecord\Features</Filter>
     </ClInclude>
-    <ClInclude Include="Features\ConditionalExec.hpp">
-      <Filter>SourceAutoRecord\Features</Filter>
-    </ClInclude>
     <ClInclude Include="Features\Stats\StatsCounter.hpp">
       <Filter>SourceAutoRecord\Features\Stats</Filter>
     </ClInclude>
@@ -1072,6 +1069,9 @@
       <Filter>SourceAutoRecord\Features</Filter>
     </ClInclude>
     <ClInclude Include="Features\Tas\TasTools\AutoAimTool.hpp">
+      <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\Tas\TasTools\SetAngleTool.hpp">
       <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Fixed the issue where line following algorithm would try its hardest to follow already defined line, even if deviated from it. I taught it that it's okay to fail and it shouldn't push itself that hard. Now it follows the new line if deviated from the old one more than it should.
Additionally, added some comments to increase the group of people who can understand this code from no one to me.

Also, since mlugg hates Windows users, included his TAS tools files into VS project.