### PR TITLE
feat: TAS Controller HUD

### DIFF
--- a/src/Features/Hud/InputHud.cpp
+++ b/src/Features/Hud/InputHud.cpp
@@ -14,7 +14,8 @@ Variable sar_ihud("sar_ihud", "0", 0,
                   "1 = forward;back;moveleft;moveright,\n"
                   "2 = 1 + duck;jump;use,\n"
                   "3 = 2 + attack;attack2,\n"
-                  "4 = 3 + speed;reload.\n");
+                  "4 = 3 + speed;reload.\n"
+                  "5 = duck;jump;use;attack;attack2.\n");
 Variable sar_ihud_x("sar_ihud_x", "0", 0, "X offset of input HUD.\n");
 Variable sar_ihud_y("sar_ihud_y", "0", 0, "Y offset of input HUD.\n");
 Variable sar_ihud_button_padding("sar_ihud_button_padding", "2", 0, "Padding between buttons of input HUD.\n");
@@ -117,30 +118,46 @@ void InputHud::Paint(int slot) {
 		++element;
 	};
 
-	/*
-        Layout:
+	if (mode != 5) {
+		/*
+			Layout:
 
-            row|col0|1|2|3|4|5|6|7|8
-            ---|---------------------
-              0|       w|e|r
-              1|shft|a|s|d
-              2|ctrl|spacebar   |l|r
-    */
+				row|col0|1|2|3|4|5|6|7|8
+				---|---------------------
+				  0|       w|e|r
+				  1|shft|a|s|d
+				  2|ctrl|spacebar   |l|r
+		*/
 
-	DrawElement(1, mvForward, col2, row0);
-	DrawElement(1, mvLeft, col1, row1);
-	DrawElement(1, mvBack, col2, row1);
-	DrawElement(1, mvRight, col3, row1);
+		DrawElement(1, mvForward, col2, row0);
+		DrawElement(1, mvLeft, col1, row1);
+		DrawElement(1, mvBack, col2, row1);
+		DrawElement(1, mvRight, col3, row1);
 
-	DrawElement(2, mvDuck, col0, row2);
-	DrawElement(2, mvJump, col1, row2, col6);
-	DrawElement(2, mvUse, col3, row0);
+		DrawElement(2, mvDuck, col0, row2);
+		DrawElement(2, mvJump, col1, row2, col6);
+		DrawElement(2, mvUse, col3, row0);
 
-	DrawElement(3, mvAttack, col7, row2);
-	DrawElement(3, mvAttack2, col8, row2);
+		DrawElement(3, mvAttack, col7, row2);
+		DrawElement(3, mvAttack2, col8, row2);
 
-	DrawElement(4, mvSpeed, col0, row1);
-	DrawElement(4, mvReload, col4, row0);
+		DrawElement(4, mvSpeed, col0, row1);
+		DrawElement(4, mvReload, col4, row0);
+	} else {
+		/*
+			Layout:
+
+				row|col0|1|2|3|4 |5|6|7
+				---|---------------------
+				  2|ctrl|spacebar|e|l|r
+		*/
+		element = 4;
+		DrawElement(5, mvDuck, col0, row2);
+		DrawElement(5, mvJump, col1, row2, col4);
+		DrawElement(5, mvUse, col5, row2);
+		DrawElement(5, mvAttack, col6, row2);
+		DrawElement(5, mvAttack2, col7, row2);
+	}
 }
 bool InputHud::GetCurrentSize(int &xSize, int &ySize) {
 	auto mode = sar_ihud.GetInt();

--- a/src/Features/Hud/InputHud.cpp
+++ b/src/Features/Hud/InputHud.cpp
@@ -58,7 +58,6 @@ const int col7 = 7;
 const int col8 = 8;
 
 InputHud inputHud;
-InputHud inputHud2;
 
 InputHud::InputHud()
 	: Hud(HudType_InGame | HudType_LoadingScreen, true)

--- a/src/Features/Hud/TasControllerHud.cpp
+++ b/src/Features/Hud/TasControllerHud.cpp
@@ -1,0 +1,128 @@
+#include "TasControllerHud.hpp"
+
+#include "Modules/Client.hpp"
+#include "Modules/Engine.hpp"
+#include "Modules/Scheme.hpp"
+#include "Modules/Surface.hpp"
+#include "Variable.hpp"
+
+#include "Features/Tas/TasController.hpp"
+
+#include <algorithm>
+
+TasControllerHud tasControllerHud;
+
+Variable sar_tas_controller_hud("sar_tas_controller_hud", "0", "Enables or disables the TAS controller HUD on screen.\n");
+Variable sar_tas_controller_hud_x("sar_tas_controller_hud_x", "10", -99999, 99999, "Sets the X position of the TAS controller HUD.\n");
+Variable sar_tas_controller_hud_y("sar_tas_controller_hud_y", "-10", -99999, 99999, "Sets the Y position of the TAS controller HUD.\n");
+Variable sar_tas_controller_hud_bg("sar_tas_controller_hud_bg", "0 0 0 192", "RGBA background cololr of the TAS controller HUD.\n", 0);
+
+TasControllerHud::TasControllerHud()
+	: Hud(HudType_InGame, true) {
+}
+bool TasControllerHud::ShouldDraw() {
+	bool shouldDraw = sar_tas_controller_hud.GetBool() && Hud::ShouldDraw();
+	return shouldDraw;
+}
+
+void TasControllerHud::Paint(int slot) {
+	// update angles array
+	if (queryNewAngles) {
+		this->angles[1] = this->angles[0];
+		this->angles[0] = engine->GetAngles(GET_SLOT());
+		queryNewAngles = false;
+	}
+
+	// do the actual drawing
+	auto font = scheme->GetDefaultFont() + 3;
+
+	int cX = sar_tas_controller_hud_x.GetInt();
+	int cY = sar_tas_controller_hud_y.GetInt();
+
+	int xScreen, yScreen;
+#if _WIN32
+	engine->GetScreenSize(xScreen, yScreen);
+#else
+	engine->GetScreenSize(nullptr, xScreen, yScreen);
+#endif
+
+	const int joystickSize = 200;
+	const int joystickPadding = 10;
+	const int vertPadding = 30;
+
+	int bgWidth = joystickSize * 2 + joystickPadding * 4;
+	int bgHeight = joystickSize + joystickPadding * 2 + vertPadding * 2;
+
+	if (cX < 0)
+		cX = xScreen + cX - bgWidth;
+	if (cY < 0)
+		cY = yScreen + cY - bgHeight;
+
+	int bgR, bgG, bgB, bgA;
+	sscanf(sar_tas_controller_hud_bg.GetString(), "%i%i%i%i", &bgR, &bgG, &bgB, &bgA);
+	surface->DrawRect(Color(bgR, bgG, bgB, bgA), cX, cY, cX + bgWidth, cY + bgHeight);
+
+	for (int i = 0; i < 2; i++) {
+
+		int jX = cX + joystickPadding * (2*i + 1) + joystickSize * i;
+		int jY = cY + joystickPadding + vertPadding;
+
+		int r = joystickSize/2;
+
+		surface->DrawColoredLine(jX, jY, jX + joystickSize, jY, Color(192, 192, 192, 128));
+		surface->DrawColoredLine(jX, jY, jX, jY + joystickSize, Color(192, 192, 192, 128));
+		surface->DrawColoredLine(jX + joystickSize, jY, jX + joystickSize, jY + joystickSize, Color(192, 192, 192, 128));
+		surface->DrawColoredLine(jX, jY + joystickSize, jX + joystickSize, jY + joystickSize, Color(192, 192, 192, 128));
+
+		surface->DrawFilledCircle(jX + r, jY + r, r, Color(0, 0, 0, 128));
+		surface->DrawCircle(jX + r, jY + r, r, Color(192, 192, 192, 128));
+
+		surface->DrawColoredLine(jX, jY + r, jX + joystickSize, jY + r, Color(192, 192, 192, 64));
+		surface->DrawColoredLine(jX + r, jY, jX + r, jY + joystickSize, Color(192, 192, 192, 64));
+
+		Vector v, visV;
+		if (i == 0) {
+			// recalculate movement values into controller inputs
+			v = movement;
+			v.y /= cl_forwardspeed.GetFloat();
+			v.x /= cl_sidespeed.GetFloat();
+			visV = v;
+			visV.y *= -1;
+		} else {
+			// calculating the difference between angles in two frames
+			v = {
+				angles[1].y - angles[0].y,
+				angles[1].x - angles[0].x,
+			};
+
+			while (v.x < -180.0f) v.x += 360.0f;
+			if (v.x > 180.0f) v.x -= 360.0f;
+
+			// make lower range of inputs easier to notice
+			if (v.Length() > 0) {
+				visV = v.Normalize() * pow(v.Length() / 180.0f, 0.2);
+				visV.y *= -1;
+			}
+		}
+
+		Color pointerColor = (i == 0) ? Color(255, 150, 0) : Color(0, 150, 255);
+		Vector pointerPoint = {jX + r + r * visV.x, jY + r + r * visV.y};
+		surface->DrawColoredLine(jX + r, jY + r, pointerPoint.x, pointerPoint.y, pointerColor);
+		surface->DrawFilledCircle(pointerPoint.x, pointerPoint.y, 10, pointerColor);
+
+		Color textColor = Color(255, 255, 255, 255);
+		surface->DrawTxt(font, jX, jY + joystickSize + 15, textColor, "x:%.3f", v.x);
+		surface->DrawTxt(font, jX + r, jY + joystickSize + 15, textColor, "y:%.3f", v.y);
+
+		surface->DrawTxt(font, jX, jY - 20, textColor, i == 0 ? "movement" : "angles", v.x);
+	}
+}
+
+bool TasControllerHud::GetCurrentSize(int &xSize, int &ySize) {
+	return false;
+}
+
+void TasControllerHud::AddData(Vector movement) {
+	this->movement = movement;
+	queryNewAngles = true;
+}

--- a/src/Features/Hud/TasControllerHud.hpp
+++ b/src/Features/Hud/TasControllerHud.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "Command.hpp"
+#include "Hud.hpp"
+#include "Variable.hpp"
+
+#include <climits>
+
+
+class TasControllerHud : public Hud {
+private:
+	Vector movement;
+	// Storing past angles data to get the difference
+	QAngle angles[2];
+	bool queryNewAngles = true;
+public:
+	TasControllerHud();
+	bool ShouldDraw() override;
+	void Paint(int slot) override;
+	bool GetCurrentSize(int &xSize, int &ySize) override;
+	void AddData(Vector movement);
+};
+
+extern TasControllerHud tasControllerHud;
+
+extern Variable sar_tas_controller_hud;
+extern Variable sar_tas_controller_hud_offset_x;
+extern Variable sar_tas_controller_hud_offset_y;
+extern Variable sar_tas_controller_hud_bg;

--- a/src/Features/Tas/TasPlayer.cpp
+++ b/src/Features/Tas/TasPlayer.cpp
@@ -3,6 +3,7 @@
 #include "Features/Session.hpp"
 #include "Features/Tas/TasParser.hpp"
 #include "Features/Tas/TasTool.hpp"
+#include "Features/Hud/Hud.hpp"
 #include "Modules/Client.hpp"
 #include "Modules/Console.hpp"
 #include "Modules/Engine.hpp"
@@ -483,4 +484,14 @@ CON_COMMAND(sar_tas_save_raw, "sar_tas_save_raw - saves a processed version of j
 	}
 
 	tasPlayer->SaveProcessedFramebulks();
+}
+
+
+HUD_ELEMENT2(tastick, "0", "Draws current TAS playback tick.\n", HudType_InGame | HudType_Paused | HudType_Menu | HudType_LoadingScreen) {
+	if (!tasPlayer->IsActive()) {
+		ctx->DrawElement("tastick: -");
+	} else {
+		int tick = tasPlayer->GetTick();
+		ctx->DrawElement("tastick: %i (%.3f)", tick, engine->ToTime(tick));
+	}
 }

--- a/src/Modules/Client.cpp
+++ b/src/Modules/Client.cpp
@@ -10,6 +10,7 @@
 #include "Features/Hud/InputHud.hpp"
 #include "Features/Hud/ScrollSpeed.hpp"
 #include "Features/Hud/StrafeQuality.hpp"
+#include "Features/Hud/TasControllerHud.hpp"
 #include "Features/Imitator.hpp"
 #include "Features/NetMessage.hpp"
 #include "Features/OffsetFinder.hpp"
@@ -306,6 +307,7 @@ DETOUR(Client::DecodeUserCmdFromBuffer, int nSlot, int buf, signed int sequence_
 		bool grounded = groundHandle != 0xFFFFFFFF;
 		groundFramesCounter->HandleMovementFrame(nSlot, grounded);
 		strafeQuality.OnMovement(nSlot, grounded);
+		tasControllerHud.AddData({cmd->sidemove, cmd->forwardmove, cmd->upmove});
 	}
 
 	return result;

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -9,6 +9,7 @@
 #include "Features/Hud/Crosshair.hpp"
 #include "Features/Hud/ScrollSpeed.hpp"
 #include "Features/Hud/StrafeQuality.hpp"
+#include "Features/Hud/TasControllerHud.hpp"
 #include "Features/NetMessage.hpp"
 #include "Features/OffsetFinder.hpp"
 #include "Features/Routing/EntityInspector.hpp"
@@ -207,6 +208,7 @@ DETOUR(Server::ProcessMovement, void *player, CMoveData *move) {
 	groundFramesCounter->HandleMovementFrame(slot, grounded);
 	strafeQuality.OnMovement(slot, grounded);
 	if (move->m_nButtons & IN_JUMP) scrollSpeedHud.OnJump(slot);
+	tasControllerHud.AddData(Vector(move->m_flSideMove, move->m_flForwardMove, move->m_flUpMove));
 
 	return Server::ProcessMovement(thisptr, player, move);
 }

--- a/src/SourceAutoRecord.vcxproj
+++ b/src/SourceAutoRecord.vcxproj
@@ -158,6 +158,7 @@
     <ClCompile Include="Features\Hud\StrafeSyncHud.cpp" />
     <ClCompile Include="Features\Hud\StrafeQuality.cpp" />
     <ClCompile Include="Features\Hud\ScrollSpeed.cpp" />
+    <ClCompile Include="Features\Hud\TasControllerHud.cpp" />
     <ClCompile Include="Features\Hud\VphysHud.cpp" />
     <ClCompile Include="Features\Hud\PortalgunHud.cpp" />
     <ClCompile Include="Features\Hud\LPHud.cpp" />
@@ -337,6 +338,7 @@
     <ClInclude Include="Features\Hud\StrafeSyncHud.hpp" />
     <ClInclude Include="Features\Hud\StrafeQuality.hpp" />
     <ClInclude Include="Features\Hud\ScrollSpeed.hpp" />
+    <ClInclude Include="Features\Hud\TasControllerHud.hpp" />
     <ClInclude Include="Features\Hud\VphysHud.hpp" />
     <ClInclude Include="Features\Hud\PortalgunHud.hpp" />
     <ClInclude Include="Features\Hud\LPHud.hpp" />

--- a/src/SourceAutoRecord.vcxproj.filters
+++ b/src/SourceAutoRecord.vcxproj.filters
@@ -418,6 +418,9 @@
     <ClCompile Include="Features\Tas\TasTools\SetAngleTool.cpp">
       <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
     </ClCompile>
+    <ClCompile Include="Features\Hud\TasControllerHud.cpp">
+      <Filter>SourceAutoRecord\Features\Hud</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\minhook\buffer.h">
@@ -1073,6 +1076,9 @@
     </ClInclude>
     <ClInclude Include="Features\Tas\TasTools\SetAngleTool.hpp">
       <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\Hud\TasControllerHud.hpp">
+      <Filter>SourceAutoRecord\Features\Hud</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Special HUD, `sar_tas_controller_hud`, allowing to preview movement and view analog inputs made by the TAS virtual controller.
Along with that, new ihud mode which doesn't include WSAD and have all buttons laid horizontally, so it is possible to align it nicely with the controller HUD in order to create Mega TAS HUD.