### PR TITLE
feat: fix Reloaded time portals invading player's console.

### DIFF
--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -6,6 +6,7 @@
 #include "Features/Hud/SpeedrunHud.hpp"
 #include "Features/Imitator.hpp"
 #include "Features/Listener.hpp"
+#include "Features/ReloadedFix.hpp"
 #include "Features/ReplaySystem/ReplayPlayer.hpp"
 #include "Features/ReplaySystem/ReplayProvider.hpp"
 #include "Features/Routing/EntityInspector.hpp"
@@ -152,6 +153,8 @@ void Cheats::Init() {
 	sar_workshop.UniqueFor(SourceGame_Portal2 | SourceGame_ApertureTag);
 	sar_workshop_update.UniqueFor(SourceGame_Portal2 | SourceGame_ApertureTag);
 	sar_workshop_list.UniqueFor(SourceGame_Portal2 | SourceGame_ApertureTag);
+
+	sar_fix_reloaded_cheats.UniqueFor(SourceGame_PortalReloaded);
 
 	cvars->Unlock();
 

--- a/src/Features.hpp
+++ b/src/Features.hpp
@@ -13,6 +13,7 @@
 #include "Features/OffsetFinder.hpp"
 #include "Features/PlayerTrace.hpp"
 #include "Features/Rebinder.hpp"
+#include "Features/ReloadedFix.hpp"
 #include "Features/ReplaySystem/ReplayPlayer.hpp"
 #include "Features/ReplaySystem/ReplayProvider.hpp"
 #include "Features/ReplaySystem/ReplayRecorder.hpp"

--- a/src/Features/ReloadedFix.cpp
+++ b/src/Features/ReloadedFix.cpp
@@ -1,0 +1,72 @@
+#include "ReloadedFix.hpp"
+
+#include "Modules/Server.hpp"
+#include "Modules/Engine.hpp"
+#include "Modules/Client.hpp"
+#include "Utils/SDK.hpp"
+#include "SAR.hpp"
+
+Variable sar_fix_reloaded_cheats(
+	"sar_fix_reloaded_cheats", "1", 0, 1,
+	"Overrides map execution of specific console commands in Reloaded in order to separate map usage from player usage for these commands.\n"
+);
+
+ReloadedFix *reloadedFix;
+
+ReloadedFix::ReloadedFix() {
+	this->hasLoaded = true;
+}
+
+// Cancels execution of certain event calls in Reloaded and replaces it with custom behaviour
+void ReloadedFix::OverrideInput(const char *className, const char *inputName, variant_t *parameter) {
+	// only apply input override for Reloaded
+	if (!sar.game->Is(SourceGame_PortalReloaded)) return;
+
+	if (!sar_fix_reloaded_cheats.GetBool()) return;
+
+	std::string paramStr = parameter->ToString();
+
+	// check commands
+	if (!strcmp(className, "point_servercommand") && !strcmp(inputName, "Command")) {
+		if (paramStr.find("clear") == 0) {
+			parameter->iszVal = "";
+		} else if (paramStr.find("sv_cheats") == 0) {
+			parameter->iszVal = "";
+			inMapCheatsEnabled = paramStr.size() > 10 && paramStr[10] != '0';
+		} else if (paramStr.find("change_portalgun_linkage_id") == 0) {
+			parameter->iszVal = "";
+			if (inMapCheatsEnabled) {
+				std::string new_cmd = Utils::ssprintf("sv_cheats 1; %s; sv_cheats %s", paramStr.c_str(), sv_cheats.GetString());
+				engine->Cbuf_AddText(2, new_cmd.c_str(), 0); // cbuf 2 = CBUF_SERVER; this is what a point_servercommand normally does
+			}
+		}
+	}
+
+	// override the vscript function where change_portalgun_linkage_id is used
+	if (!strcmp(inputName, "RunScriptCode") && !paramStr.compare("setPortalID()")) {
+		parameter->iszVal = "";
+		CustomSetPortalID();
+	}
+}
+
+
+// this is a rewrite of a vscript function implemented in Reloaded with "fixed" change_portalgun_linkage_id
+void ReloadedFix::CustomSetPortalID() {
+	auto player = client->GetPlayer(GET_SLOT() + 1);
+	if (!player) return;
+
+	auto pos = client->GetAbsOrigin(player);
+
+	int linkageId = (pos.y < 0) ? 0 : 1;
+	char linkageCmd[128];
+	snprintf(linkageCmd, sizeof(linkageCmd), "sv_cheats 1;change_portalgun_linkage_id %d;sv_cheats %s", linkageId, sv_cheats.GetString());
+	if (inMapCheatsEnabled) engine->ExecuteCommand(linkageCmd);
+
+	if (pos.y < 0) {
+		engine->ExecuteCommand("ent_fire @present_teleport Trigger");
+	} else {
+		engine->ExecuteCommand("ent_fire @future_teleport Trigger");
+	}
+
+	engine->ExecuteCommand("ent_fire @draw_ghosting Trigger");
+}

--- a/src/Features/ReloadedFix.hpp
+++ b/src/Features/ReloadedFix.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Feature.hpp"
+#include "Utils/SDK.hpp"
+#include "Variable.hpp"
+
+class ReloadedFix : public Feature {
+public:
+	bool inMapCheatsEnabled = false;
+public:
+	ReloadedFix();
+	void OverrideInput(const char *className, const char *inputName, variant_t* parameter);
+private:
+	void CustomSetPortalID();
+};
+
+extern ReloadedFix *reloadedFix;
+
+
+extern Variable sar_fix_reloaded_cheats;

--- a/src/Features/Tas/TasPlayer.cpp
+++ b/src/Features/Tas/TasPlayer.cpp
@@ -424,14 +424,26 @@ void TasPlayer::Update() {
 
 DECL_COMMAND_COMPLETION(sar_tas_play) {
 	try {
-		for (auto const &file : std::filesystem::recursive_directory_iterator(TAS_SCRIPTS_DIR)) {
+		for (
+			auto i = std::filesystem::recursive_directory_iterator(TAS_SCRIPTS_DIR);
+			i != std::filesystem::recursive_directory_iterator();
+			++i
+		) {
 			if (items.size() == COMMAND_COMPLETION_MAXITEMS) {
 				break;
 			}
 
-			auto scriptName = file.path().stem().string();
+			auto file = *i;
+
 			auto scriptExt = file.path().extension().string();
 			if (Utils::EndsWith(scriptExt, TAS_SCRIPT_EXT)) {
+				auto scriptPath = file.path();
+				auto scriptName = scriptPath.stem().string();
+				for (int d = 0; d < i.depth(); d++) {
+					scriptPath = scriptPath.parent_path();
+					scriptName = scriptPath.stem().string() + "/" + scriptName;
+				}
+
 				if (std::strstr(scriptName.c_str(), match)) {
 					items.push_back(scriptName);
 				}

--- a/src/Features/Tas/TasPlayer.cpp
+++ b/src/Features/Tas/TasPlayer.cpp
@@ -411,9 +411,9 @@ void TasPlayer::Update() {
 
 	if (startTick != -1 && active && ready) {
 		if (paused) {
-			engine->ExecuteCommand("setpause", true);
+			//engine->ExecuteCommand("setpause", true);
 		} else {
-			engine->ExecuteCommand("unpause", true);
+			//engine->ExecuteCommand("unpause", true);
 		}
 	}
 }

--- a/src/Features/Tas/TasPlayer.cpp
+++ b/src/Features/Tas/TasPlayer.cpp
@@ -138,9 +138,13 @@ void TasPlayer::PostStart() {
 	engine->ExecuteCommand("phys_timescale 1", true);  // technically it was supposed to fix the consistency issue
 }
 
-void TasPlayer::Stop() {
+void TasPlayer::Stop(bool interrupted) {
 	if (active && ready) {
-		console->Print("TAS script has ended after %d ticks.\n", currentTick);
+		console->Print(
+			"TAS script has %s after %d ticks.\n", 
+			interrupted ? "been interrupted" : "ended", 
+			currentTick
+		);
 
 		if (sar_tas_autosave_raw.GetBool()) {
 			SaveProcessedFramebulks();
@@ -372,7 +376,7 @@ void TasPlayer::Update() {
 			}
 		}
 		if (ready && session->isRunning) {
-			if (startTick == -1) {
+			if (!IsRunning()) {
 				PostStart();  // script has started its playback. Adjust the tick counter and offset
 			} else {
 				currentTick++;
@@ -477,7 +481,7 @@ CON_COMMAND(sar_tas_advance, "sar_tas_advance - advances TAS playback by one tic
 }
 
 CON_COMMAND(sar_tas_stop, "sar_tas_stop - stop TAS playing\n") {
-	tasPlayer->Stop();
+	tasPlayer->Stop(true);
 }
 
 CON_COMMAND(sar_tas_save_raw, "sar_tas_save_raw - saves a processed version of just processed script\n") {

--- a/src/Features/Tas/TasPlayer.cpp
+++ b/src/Features/Tas/TasPlayer.cpp
@@ -345,6 +345,10 @@ void TasPlayer::PostProcess(void *player, CMoveData *pMove) {
 	}
 	pMove->m_flSideMove = cl_sidespeed.GetFloat() * fb.moveAnalog.x;
 
+	// making sure none of the move values are NaN
+	if (std::isnan(pMove->m_flForwardMove)) pMove->m_flForwardMove = 0;
+	if (std::isnan(pMove->m_flSideMove)) pMove->m_flForwardMove = 0;
+
 	pMove->m_nButtons = 0;
 	for (int i = 0; i < TAS_CONTROLLER_INPUT_COUNT; i++) {
 		if (g_TasControllerInGameButtons[i] && fb.buttonStates[i]) {

--- a/src/Features/Tas/TasPlayer.hpp
+++ b/src/Features/Tas/TasPlayer.hpp
@@ -73,11 +73,12 @@ public:
 	inline int GetTick() const { return currentTick; };
 	inline int GetAbsoluteTick() const { return startTick + currentTick; };
 	inline bool IsActive() const { return active; };
+	inline bool IsRunning() const { return active && startTick != -1; }
 
 	void Activate();
 	void Start();
 	void PostStart();
-	void Stop();
+	void Stop(bool interrupted=false);
 
 	void Pause();
 	void Resume();

--- a/src/Modules/Engine.cpp
+++ b/src/Modules/Engine.cpp
@@ -14,6 +14,7 @@
 #include "Features/SegmentedTools.hpp"
 #include "Features/Session.hpp"
 #include "Features/Speedrun/SpeedrunTimer.hpp"
+#include "Features/Tas/TasPlayer.hpp"
 #include "Game.hpp"
 #include "Hook.hpp"
 #include "Interface.hpp"
@@ -338,6 +339,11 @@ DETOUR(Engine::Frame) {
 	Renderer::Frame();
 
 	NetMessage::Update();
+
+	// stopping TAS player if outside of the game
+	if (!engine->hoststate->m_activeGame && tasPlayer->IsRunning()) {
+		tasPlayer->Stop(true);
+	}
 
 	return Engine::Frame(thisptr);
 }

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -12,6 +12,7 @@
 #include "Features/Hud/TasControllerHud.hpp"
 #include "Features/NetMessage.hpp"
 #include "Features/OffsetFinder.hpp"
+#include "Features/ReloadedFix.hpp"
 #include "Features/Routing/EntityInspector.hpp"
 #include "Features/Routing/SeamshotFind.hpp"
 #include "Features/SegmentedTools.hpp"
@@ -411,6 +412,9 @@ static void __cdecl AcceptInput_Hook(void *thisptr, const char *inputName, void 
 			TriggerCMFlag(0, time, true);
 		}
 	}
+
+	// allow reloaded fix to override some commands from point_servercommand
+	reloadedFix->OverrideInput(className, inputName, &parameter);
 
 	g_AcceptInputHook.Disable();
 	server->AcceptInput(thisptr, inputName, activator, caller, parameter, outputID);

--- a/src/SAR.cpp
+++ b/src/SAR.cpp
@@ -68,6 +68,7 @@ bool SAR::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceFn gameServerF
 			SpeedrunTimer::Init();
 			this->features->AddFeature<Stats>(&stats);
 			this->features->AddFeature<Sync>(&synchro);
+			this->features->AddFeature<ReloadedFix>(&reloadedFix);
 			this->features->AddFeature<ReplayRecorder>(&replayRecorder1);
 			this->features->AddFeature<ReplayRecorder>(&replayRecorder2);
 			this->features->AddFeature<ReplayPlayer>(&replayPlayer1);

--- a/src/SourceAutoRecord.vcxproj
+++ b/src/SourceAutoRecord.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="Features\OffsetFinder.cpp" />
     <ClCompile Include="Features\PlayerTrace.cpp" />
     <ClCompile Include="Features\Rebinder.cpp" />
+    <ClCompile Include="Features\ReloadedFix.cpp" />
     <ClCompile Include="Features\Routing\EntityInspector.cpp" />
     <ClCompile Include="Features\Routing\SeamshotFind.cpp" />
     <ClCompile Include="Features\Routing\Tracer.cpp" />
@@ -348,6 +349,7 @@
     <ClInclude Include="Features\OffsetFinder.hpp" />
     <ClInclude Include="Features\PlayerTrace.hpp" />
     <ClInclude Include="Features\Rebinder.hpp" />
+    <ClInclude Include="Features\ReloadedFix.hpp" />
     <ClInclude Include="Features\Routing\EntityInspector.hpp" />
     <ClInclude Include="Features\Routing\SeamshotFind.hpp" />
     <ClInclude Include="Features\Routing\Tracer.hpp" />

--- a/src/SourceAutoRecord.vcxproj.filters
+++ b/src/SourceAutoRecord.vcxproj.filters
@@ -421,6 +421,9 @@
     <ClCompile Include="Features\Hud\TasControllerHud.cpp">
       <Filter>SourceAutoRecord\Features\Hud</Filter>
     </ClCompile>
+    <ClCompile Include="Features\ReloadedFix.cpp">
+      <Filter>SourceAutoRecord\Features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\minhook\buffer.h">
@@ -1079,6 +1082,9 @@
     </ClInclude>
     <ClInclude Include="Features\Hud\TasControllerHud.hpp">
       <Filter>SourceAutoRecord\Features\Hud</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\ReloadedFix.hpp">
+      <Filter>SourceAutoRecord\Features</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Portal Reloaded uses `change_portalgun_linkage_id` command in order to handle placing present and future portals, as well as a time portal. This command, however, is cheat protected, so in addition, the game enables and disables `sv_cheats` when attempting to use that command. This is inconvenient for TASers and routers, who prefer to have server cheats constantly enabled. This can be fixed by "aliasing" `sv_cheats` so that it can never be executed again. 

However, that eliminates pretty useful glitch called Portal Time Heist, which abuses the fact that we can cause the game to disable server cheats before changing portal gun linkage ID, basically allowing us to place future portals in present and vice-versa.

This fix attempts to eliminate those issues by separating game's and user's usage of server cheats. This is done by interrupting specific entity event calls and replacing them with custom behavior that imitates the one seen in the game.


Additionally, I've (hopefully) fixed a bug where TAS Player could generate NaN values for movement at specific conditions.