### PR TITLE
Custom keys for iHud

### DIFF
--- a/src/Features/Hud/InputHud.hpp
+++ b/src/Features/Hud/InputHud.hpp
@@ -20,6 +20,7 @@ private:
 		std::string name;
 		bool isVector;
 		int type;
+		bool isNormalKey = false;
 
 		//visual
 		bool enabled;
@@ -34,7 +35,6 @@ private:
 		Color textColor;
 		Color textHighlight;
 	};
-	std::vector<InputHudElement> elements;
 
 public:
 	InputHud();
@@ -49,6 +49,10 @@ public:
 	bool IsValidParameter(const char *parameter);
 
 	int GetButtonBits(int slot) { return inputInfo[slot].buttonBits; }
+
+	void AddElement(std::string name, int type);
+
+	std::vector<InputHudElement> elements;
 };
 
 extern InputHud inputHud;

--- a/src/Features/Hud/InputHud.hpp
+++ b/src/Features/Hud/InputHud.hpp
@@ -36,6 +36,8 @@ private:
 		Color textHighlight;
 	};
 
+	InputHudElement *GetElementByName(std::string name);
+
 public:
 	InputHud();
 	void SetInputInfo(int slot, int buttonBits, Vector movement);
@@ -47,6 +49,7 @@ public:
 	void ApplyPreset(const char *preset, bool start);
 	bool HasElement(const char *elementName);
 	bool IsValidParameter(const char *parameter);
+	std::string GetParameterValue(std::string name, std::string parameter);
 
 	int GetButtonBits(int slot) { return inputInfo[slot].buttonBits; }
 


### PR DESCRIPTION
This allows you to add any key to ihud, by using the command `sar_ihud_add_key <key>`. This will add a new key element to ihud that you can modify just like any other element by using the key name as the name in `sar_ihud_modify`.
Example: `sar_ihud_add_key p` => `sar_ihud_modify p x=2`

You can also now get the values of the parameters each element has, by using `sar_ihud_modify` but not assigning the values.
Example: `sar_ihud_modify movement enabled` => `movement: enabled=1`
This works with every parameter a key element has, with multiple parameters in the same command and with "all" as the element name.