### PR TITLE
Fix analog move going out of the unit circle.

### DIFF
--- a/src/Features/Tas/TasPlayer.cpp
+++ b/src/Features/Tas/TasPlayer.cpp
@@ -464,6 +464,9 @@ void TasPlayer::PostProcess(int slot, void *player, CUserCmd *cmd) {
 		tool->Apply(fb, playerInfo);
 	}
 
+	if (fb.moveAnalog.Length2D() > 1)
+		fb.moveAnalog = fb.moveAnalog.Normalize();
+
 	// add processed framebulk to the cmd
 	// using angles from playerInfo, as these seem to be the most accurate
 	// cmd ones are created before tool parsing and GetAngles is wacky.


### PR DESCRIPTION
Due to the implementation of `nopitchlock`, the move analog y was able to go outside of the normal range of controller inputs, mostly visible on the ihud.
By clamping the move analog, this is prevented.
Thankfully this doesn't break any TASses since the input was clamped server side.