### PR TITLE
fix: thread-safe pride

### DIFF
--- a/src/Modules/Console.hpp
+++ b/src/Modules/Console.hpp
@@ -28,6 +28,11 @@
 		console->Print(__VA_ARGS__); \
 	})
 
+#define THREAD_PRINTCOLOR(...) \
+	Scheduler::OnMainThread([=]() { \
+		console->ColorMsg(__VA_ARGS__); \
+	})
+
 class Console : public Module {
 public:
 	using _Msg = void(__cdecl *)(const char *pMsgFormat, ...);

--- a/src/SAR.cpp
+++ b/src/SAR.cpp
@@ -27,8 +27,8 @@ SAR sar;
 EXPOSE_SINGLE_INTERFACE_GLOBALVAR(SAR, IServerPluginCallbacks, INTERFACEVERSION_ISERVERPLUGINCALLBACKS, sar);
 
 static void doPride() {
-#define FILL(n,c) for (size_t i = 0; i < n; ++i) console->ColorMsg(c, "#");
-#define NL console->Print("\n     ");
+#define FILL(n,c) for (size_t i = 0; i < n; ++i) THREAD_PRINTCOLOR(c, "#");
+#define NL THREAD_PRINT("\n     ");
 #define RED Color{255,0,0}
 #define ORANGE Color{255,155,0}
 #define YELLOW Color{230,255,0}
@@ -98,14 +98,14 @@ static void doPride() {
 	FILL(40, PURPLE)
 	NL
 
-	console->Print("\nHappy pride month to all members of the ");
-	console->ColorMsg(RED, "L");
-	console->ColorMsg(ORANGE, "G");
-	console->ColorMsg(YELLOW, "B");
-	console->ColorMsg(GREEN, "T");
-	console->ColorMsg(BLUE, "Q");
-	console->ColorMsg(PURPLE, "+");
-	console->Print(" community!\n\n");
+	THREAD_PRINT("\nHappy pride month to all members of the ");
+	THREAD_PRINTCOLOR(RED, "L");
+	THREAD_PRINTCOLOR(ORANGE, "G");
+	THREAD_PRINTCOLOR(YELLOW, "B");
+	THREAD_PRINTCOLOR(GREEN, "T");
+	THREAD_PRINTCOLOR(BLUE, "Q");
+	THREAD_PRINTCOLOR(PURPLE, "+");
+	THREAD_PRINT(" community!\n\n");
 
 #undef FILL
 #undef NL


### PR DESCRIPTION
The pride feature was not thread safe at all (untested?)
![Screenshot-2022-01-13,17-41-45](https://user-images.githubusercontent.com/69196954/149280521-5e28124c-337d-424c-998b-c45f5460f4c6.png)
Now it is :)
![Screenshot-2022-01-13,17-42-40](https://user-images.githubusercontent.com/69196954/149280580-d8a817b0-1ac6-4f3c-9299-9edade110260.png)

