### PR TITLE
Config plus features

### DIFF
--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -1005,6 +1005,10 @@ static void expand(const CCommand &args, std::string body) {
 				}
 				++i;
 				continue;
+			} else if (body[i + 1] == '#') {
+				cmd += std::to_string(nargs);
+				++i;
+				continue;	
 			} else if (body[i + 1] >= '1' && body[i + 1] <= '9') {
 				unsigned arg = body[i + 1] - '0';
 				if (body[i + 2] >= '0' && body[i + 2] <= '9') {

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -947,8 +947,10 @@ CON_COMMAND_F(sar_function, "sar_function <name> [command] [args]... - create a 
 	g_functions[std::string(args[1])] = {c, cmd, name};
 }
 
-static void expand(size_t nargs, const char *const *args, std::string body) {
+static void expand(const CCommand &args, std::string body) {
+
 	std::string cmd;
+	unsigned nargs = args.ArgC() - 2;
 
 	for (size_t i = 0; i < body.size(); ++i) {
 		if (body[i] == '$') {
@@ -965,9 +967,27 @@ static void expand(size_t nargs, const char *const *args, std::string body) {
 				// to svar subs
 				++i;
 				continue;
+			} else if (body[i + 1] == '+') {
+				++i;
+				if (body[i + 1] >= '1' && body[i + 1] <= '9') {
+					unsigned arg = body[i + 1] - '0';
+					if (arg <= nargs) {
+						const char *argcat = args.m_pArgSBuffer + args.m_nArgv0Size;
+						while (isspace(*argcat)) ++argcat;
+						for (unsigned j = 1; j < arg + 1; ++j) {
+							argcat += (*argcat == '"' ? 2 : 0) + strlen(args[j]);
+							while (isspace(*argcat)) ++argcat;
+						}
+						cmd += argcat;
+					}
+				} else {
+					cmd += "$+";
+				}
+				++i;
+				continue;
 			} else if (body[i + 1] >= '1' && body[i + 1] <= '9') {
 				unsigned arg = body[i + 1] - '0';
-				cmd += arg - 1 < nargs ? args[arg - 1] : "";
+				cmd += arg <= nargs ? args[arg + 1] : "";
 				++i;
 				continue;
 			} else {
@@ -1008,7 +1028,8 @@ CON_COMMAND_F(sar_expand, "sar_expand [cmd]... - run a command after expanding s
 	}
 
 	const char *cmd = args.ArgC() == 2 ? args[1] : args.m_pArgSBuffer + args.m_nArgv0Size;
-	expand(0, nullptr, std::string(cmd));
+	const CCommand noArgs = {2}; // nargs = 0
+	expand(noArgs, std::string(cmd));
 }
 
 CON_COMMAND_F(sar_function_run, "sar_function_run <name> [args]... - run a function with the given arguments\n", FCVAR_DONTRECORD) {
@@ -1021,5 +1042,5 @@ CON_COMMAND_F(sar_function_run, "sar_function_run <name> [args]... - run a funct
 		return console->Print("Function %s does not exist\n", args[1]);
 	}
 
-	expand(args.ArgC() - 2, args.m_ppArgv + 2, it->second.run);
+	expand(args, it->second.run);
 }

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -987,6 +987,10 @@ static void expand(const CCommand &args, std::string body) {
 				++i;
 				if (body[i + 1] >= '1' && body[i + 1] <= '9') {
 					unsigned arg = body[i + 1] - '0';
+					if (body[i + 2] >= '0' && body[i + 2] <= '9') {
+						arg = arg * 10 + (body[i + 2] - '0');
+						++i;
+					}
 					if (arg <= nargs) {
 						const char *argcat = args.m_pArgSBuffer + args.m_nArgv0Size;
 						while (isspace(*argcat)) ++argcat;
@@ -1003,6 +1007,10 @@ static void expand(const CCommand &args, std::string body) {
 				continue;
 			} else if (body[i + 1] >= '1' && body[i + 1] <= '9') {
 				unsigned arg = body[i + 1] - '0';
+				if (body[i + 2] >= '0' && body[i + 2] <= '9') {
+					arg = arg * 10 + (body[i + 2] - '0');
+					++i;
+				}
 				cmd += arg <= nargs ? args[arg + 1] : "";
 				++i;
 				continue;

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -533,8 +533,8 @@ static Condition *ParseCondition(std::queue<Token> toks) {
 				c->type = Condition::WORKSHOP;
 			} else if (t.len == 4 && !strncmp(t.str, "menu", t.len)) {
 				c->type = Condition::MENU;
-			} else if (t.len == 3 && !strncmp(t.str, "map", t.len) || t.len == 8 && !strncmp(t.str, "prev_map", t.len) || t.len == 4 && !strncmp(t.str, "game", t.len) || t.len > 4 && !strncmp(t.str, "var:", 4)) {
-				bool is_var = !strncmp(t.str, "var:", 4);
+			} else if (t.len == 3 && !strncmp(t.str, "map", t.len) || t.len == 8 && !strncmp(t.str, "prev_map", t.len) || t.len == 4 && !strncmp(t.str, "game", t.len) || t.len > 4 && !strncmp(t.str, "var:", 4) || t.len > 1 && t.str[0] == '?') {
+				bool is_var = !strncmp(t.str, "var:", 4) || t.str[0] == '?';
 
 				if (toks.front().type != TOK_EQUALS) {
 					console->Print("Expected = after '%*s'\n", t.len, t.str);
@@ -554,10 +554,11 @@ static Condition *ParseCondition(std::queue<Token> toks) {
 				}
 
 				if (is_var) {
+					int i = t.str[0] == 'v' ? 4 : 1;
 					c->type = Condition::SVAR;
-					c->svar.var = (char *)malloc(t.len - 4 + 1);
-					strncpy(c->svar.var, t.str + 4, t.len - 4);
-					c->svar.var[t.len - 4] = 0;  // Null terminator
+					c->svar.var = (char *)malloc(t.len - i + 1);
+					strncpy(c->svar.var, t.str + i, t.len - i);
+					c->svar.var[t.len - i] = 0;  // Null terminator
 					c->svar.val = (char *)malloc(map_tok.len + 1);
 					strncpy(c->svar.val, map_tok.str, map_tok.len);
 					c->svar.val[map_tok.len] = 0;  // Null terminator

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -553,21 +553,36 @@ static Condition *ParseCondition(std::queue<Token> toks) {
 					return NULL;
 				}
 
+				char * val;
+				if (map_tok.len > 4 && !strncmp(map_tok.str, "var:", 4) || map_tok.len > 1 && map_tok.str[0] == '?') {
+					int i = map_tok.str[0] == 'v' ? 4 : 1;
+					
+					std::string value = GetSvar(std::string(map_tok.str + i));
+					val = (char *)malloc(value.length() + 1);
+					strcpy(val, value.c_str());
+					val[value.length()] = 0;  //  Null terminator
+				} else {
+					val = (char *)malloc(map_tok.len + 1);
+					strncpy(val, map_tok.str, map_tok.len);
+					val[map_tok.len] = 0;  // Null terminator
+				}
+
 				if (is_var) {
 					int i = t.str[0] == 'v' ? 4 : 1;
 					c->type = Condition::SVAR;
 					c->svar.var = (char *)malloc(t.len - i + 1);
 					strncpy(c->svar.var, t.str + i, t.len - i);
 					c->svar.var[t.len - i] = 0;  // Null terminator
-					c->svar.val = (char *)malloc(map_tok.len + 1);
-					strncpy(c->svar.val, map_tok.str, map_tok.len);
-					c->svar.val[map_tok.len] = 0;  // Null terminator
+					c->svar.val = (char *)malloc(strlen(val) + 1);
+					strncpy(c->svar.val, val, strlen(val));
+					c->svar.val[strlen(val)] = 0;  // Null terminator
 				} else {
 					c->type = t.len == 8 ? Condition::PREV_MAP : t.len == 4 ? Condition::GAME : Condition::MAP;
-					c->map = (char *)malloc(map_tok.len + 1);
-					strncpy(c->map, map_tok.str, map_tok.len);
-					c->map[map_tok.len] = 0;  // Null terminator
+					c->map = (char *)malloc(strlen(val) + 1);
+					strncpy(c->map, val, strlen(val));
+					c->map[strlen(val)] = 0;  // Null terminator
 				}
+				free(val);
 			} else {
 				console->Print("Bad token '%.*s'\n", t.len, t.str);
 				CLEAR_OUT_STACK;


### PR DESCRIPTION
- `$+x` which expands to all arguments after and including argument `x`. Effectively this makes `sar_alias` obsolete but it's still nice to use it when you can.
- `?foo=bar` shortcut for `"var:foo=bar"`. Works around breakset so you need to quote fewer conds.
- `"<...>=var:bar"` support. Very situational, reviewer's choice whether to drop or keep.
- Similarly, `<...>=?bar`.
- `$#` which expands to the number of arguments given. Not overly useful unless you're doing cursed config+++, but it's there now
- `$x` can now expand to >9 arguments. The rationale for *not* doing this is laziness, but I'm not lazy... sometimes