### PR TITLE
fix: don't record various commands in demos

### DIFF
--- a/src/Features/Hud/Hud.cpp
+++ b/src/Features/Hud/Hud.cpp
@@ -351,7 +351,7 @@ CON_COMMAND_COMPLETION(sar_hud_order_bottom, "sar_hud_order_bottom <name> - orde
 
 	console->Print("Moved HUD element %s to bottom.\n", args[1]);
 }
-CON_COMMAND(sar_hud_order_reset, "sar_hud_order_reset - resets order of hud element\n") {
+CON_COMMAND_F(sar_hud_order_reset, "sar_hud_order_reset - resets order of hud element\n", FCVAR_DONTRECORD) {
 	std::sort(vgui->elements.begin(), vgui->elements.end(), [](const HudElement *a, const HudElement *b) {
 		return a->orderIndex < b->orderIndex;
 	});
@@ -476,7 +476,7 @@ long parseIdx(const char *idxStr) {
 	return idx;
 }
 
-CON_COMMAND(sar_hud_set_text, "sar_hud_set_text <id> <text>... - sets and shows the nth text value in the HUD\n") {
+CON_COMMAND_F(sar_hud_set_text, "sar_hud_set_text <id> <text>... - sets and shows the nth text value in the HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 3) {
 		console->Print(sar_hud_set_text.ThisPtr()->m_pszHelpString);
 		return;
@@ -545,7 +545,7 @@ CON_COMMAND(sar_hud_set_text, "sar_hud_set_text <id> <text>... - sets and shows 
 	sar_hud_text_vals[idx].components = components;
 }
 
-CON_COMMAND(sar_hud_set_text_color, "sar_hud_set_text_color <id> [color] - sets the color of the nth text value in the HUD. Reset by not giving color.\n") {
+CON_COMMAND_F(sar_hud_set_text_color, "sar_hud_set_text_color <id> [color] - sets the color of the nth text value in the HUD. Reset by not giving color.\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2 || args.ArgC() > 3) {
 		console->Print(sar_hud_set_text_color.ThisPtr()->m_pszHelpString);
 		return;
@@ -566,7 +566,7 @@ CON_COMMAND(sar_hud_set_text_color, "sar_hud_set_text_color <id> [color] - sets 
 	}
 }
 
-CON_COMMAND(sar_hud_hide_text, "sar_hud_hide_text <id> - hides the nth text value in the HUD\n") {
+CON_COMMAND_F(sar_hud_hide_text, "sar_hud_hide_text <id> - hides the nth text value in the HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		console->Print(sar_hud_hide_text.ThisPtr()->m_pszHelpString);
 		return;
@@ -581,7 +581,7 @@ CON_COMMAND(sar_hud_hide_text, "sar_hud_hide_text <id> - hides the nth text valu
 	sar_hud_text_vals[idx].draw = false;
 }
 
-CON_COMMAND(sar_hud_show_text, "sar_hud_show_text <id> - shows the nth text value in the HUD\n") {
+CON_COMMAND_F(sar_hud_show_text, "sar_hud_show_text <id> - shows the nth text value in the HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		console->Print(sar_hud_show_text.ThisPtr()->m_pszHelpString);
 		return;

--- a/src/Features/Hud/Hud.hpp
+++ b/src/Features/Hud/Hud.hpp
@@ -180,7 +180,7 @@ int HudSetPos_CompleteFunc(const char *partial, char commands[COMMAND_COMPLETION
         name##_setpos,                                                                              \
         "Automatically sets the position of " helpname ".\n"                                          \
         "Usage: " #name "_setpos <top|center|bottom|y|y\%> <left|center|right|x|x\%>\n",              \
-        0, HudSetPos_CompleteFunc                                                                     \
+        FCVAR_DONTRECORD, HudSetPos_CompleteFunc                                                                     \
     ) {                                                                                               \
         if (args.ArgC() != 3) return console->Print(name##_setpos.ThisPtr()->m_pszHelpString);      \
         name##_x.SetValue(args[2]);                                                                 \

--- a/src/Features/Hud/InputHud.cpp
+++ b/src/Features/Hud/InputHud.cpp
@@ -601,7 +601,7 @@ DECL_COMMAND_COMPLETION(sar_ihud_modify) {
 CON_COMMAND_F_COMPLETION(sar_ihud_modify,
 	"sar_ihud_modify <element|all> [param=value]... - modifies parameters in given element.\n"
     "Params: enabled, text, pos, x, y, width, height, font, background, highlight, textcolor, texthighlight, image, highlightimage, minhold.\n",
-	0, sar_ihud_modify_CompletionFunc
+	FCVAR_DONTRECORD, sar_ihud_modify_CompletionFunc
 ) {
 	if (args.ArgC() < 3) {
 		console->Print(sar_ihud_modify.ThisPtr()->m_pszHelpString);
@@ -667,7 +667,7 @@ CON_COMMAND_F_COMPLETION(sar_ihud_modify,
 	}
 }
 
-CON_COMMAND(sar_ihud_add_key, "sar_ihud_add_key <key>") {
+CON_COMMAND_F(sar_ihud_add_key, "sar_ihud_add_key <key>", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		console->Print(sar_ihud_add_key.ThisPtr()->m_pszHelpString);
 		return;
@@ -689,7 +689,7 @@ CON_COMMAND(sar_ihud_add_key, "sar_ihud_add_key <key>") {
 
 CON_COMMAND_HUD_SETPOS(sar_ihud, "input HUD")
 
-CON_COMMAND(sar_ihud_set_background, "sar_ihud_set_background <path> <grid x> <grid y> <grid w> <grid h>") {
+CON_COMMAND_F(sar_ihud_set_background, "sar_ihud_set_background <path> <grid x> <grid y> <grid w> <grid h>", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 6) {
 		console->Print(sar_ihud_set_background.ThisPtr()->m_pszHelpString);
 		return;
@@ -713,6 +713,6 @@ CON_COMMAND(sar_ihud_set_background, "sar_ihud_set_background <path> <grid x> <g
 	inputHud.bgGridH = atoi(args[5]);
 }
 
-CON_COMMAND(sar_ihud_clear_background, "sar_ihud_clear_background") {
+CON_COMMAND_F(sar_ihud_clear_background, "sar_ihud_clear_background", FCVAR_DONTRECORD) {
 	inputHud.bgTextureId = -1;
 }

--- a/src/Features/Hud/Toasts.cpp
+++ b/src/Features/Hud/Toasts.cpp
@@ -87,7 +87,7 @@ static TagInfo getTagInfo(std::string tag) {
 	};
 }
 
-CON_COMMAND(sar_toast_tag_set_color, "sar_toast_tag_set_color <tag> <color> - set the color of the specified toast tag to an sRGB color\n") {
+CON_COMMAND_F(sar_toast_tag_set_color, "sar_toast_tag_set_color <tag> <color> - set the color of the specified toast tag to an sRGB color\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3 && args.ArgC() != 5) {
 		return console->Print(sar_toast_tag_set_color.ThisPtr()->m_pszHelpString);
 	}
@@ -132,7 +132,7 @@ CON_COMMAND(sar_toast_tag_set_color, "sar_toast_tag_set_color <tag> <color> - se
 	g_tags[tag] = info;
 }
 
-CON_COMMAND(sar_toast_tag_set_duration, "sar_toast_tag_set_duration <tag> <duration> - set the duration of the specified toast tag in seconds. The duration may be given as 'forever'\n") {
+CON_COMMAND_F(sar_toast_tag_set_duration, "sar_toast_tag_set_duration <tag> <duration> - set the duration of the specified toast tag in seconds. The duration may be given as 'forever'\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3) {
 		return console->Print(sar_toast_tag_set_duration.ThisPtr()->m_pszHelpString);
 	}
@@ -157,7 +157,7 @@ CON_COMMAND(sar_toast_tag_set_duration, "sar_toast_tag_set_duration <tag> <durat
 	g_tags[tag] = info;
 }
 
-CON_COMMAND(sar_toast_tag_dismiss_all, "sar_toast_tag_dismiss_all <tag> - dismiss all active toasts with the given tag\n") {
+CON_COMMAND_F(sar_toast_tag_dismiss_all, "sar_toast_tag_dismiss_all <tag> - dismiss all active toasts with the given tag\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 2) {
 		return console->Print(sar_toast_tag_dismiss_all.ThisPtr()->m_pszHelpString);
 	}
@@ -174,7 +174,7 @@ CON_COMMAND(sar_toast_tag_dismiss_all, "sar_toast_tag_dismiss_all <tag> - dismis
 		g_toasts.end());
 }
 
-CON_COMMAND(sar_toast_setpos, "sar_toast_setpos <bottom|top> <left|center|right> - set the position of the toasts HUD\n") {
+CON_COMMAND_F(sar_toast_setpos, "sar_toast_setpos <bottom|top> <left|center|right> - set the position of the toasts HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3) {
 		return console->Print(sar_toast_setpos.ThisPtr()->m_pszHelpString);
 	}
@@ -450,7 +450,7 @@ void ToastHud::Paint(int slot) {
 	}
 }
 
-CON_COMMAND(sar_toast_create, "sar_toast_create <tag> <text> - create a toast\n") {
+CON_COMMAND_F(sar_toast_create, "sar_toast_create <tag> <text> - create a toast\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3) {
 		console->Print(sar_toast_create.ThisPtr()->m_pszHelpString);
 		return;
@@ -459,7 +459,7 @@ CON_COMMAND(sar_toast_create, "sar_toast_create <tag> <text> - create a toast\n"
 	toastHud.AddToast(args[1], args[2]);
 }
 
-CON_COMMAND(sar_toast_net_create, "sar_toast_net_create <tag> <text> - create a toast, also sending it to your coop partner\n") {
+CON_COMMAND_F(sar_toast_net_create, "sar_toast_net_create <tag> <text> - create a toast, also sending it to your coop partner\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3) {
 		console->Print(sar_toast_net_create.ThisPtr()->m_pszHelpString);
 		return;
@@ -484,7 +484,7 @@ CON_COMMAND(sar_toast_net_create, "sar_toast_net_create <tag> <text> - create a 
 	}
 }
 
-CON_COMMAND(sar_toast_dismiss_all, "sar_toast_dismiss_all - dismiss all active toasts\n") {
+CON_COMMAND_F(sar_toast_dismiss_all, "sar_toast_dismiss_all - dismiss all active toasts\n", FCVAR_DONTRECORD) {
 	g_toasts.clear();
 }
 

--- a/src/Modules/Console.cpp
+++ b/src/Modules/Console.cpp
@@ -45,7 +45,7 @@ ConsoleListener::~ConsoleListener() {
 
 Console *console;
 
-CON_COMMAND(sar_echo, "sar_echo <color> <string...> - echo a string to console with a given color\n") {
+CON_COMMAND_F(sar_echo, "sar_echo <color> <string...> - echo a string to console with a given color\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		return console->Print(sar_echo.ThisPtr()->m_pszHelpString);
 	}
@@ -68,7 +68,7 @@ CON_COMMAND(sar_echo, "sar_echo <color> <string...> - echo a string to console w
 	console->ColorMsg(*col, "%s\n", str);
 }
 
-CON_COMMAND(sar_echo_nolf, "sar_echo_nolf <color> <string...> - echo a string to console with a given color and no trailing line feed\n") {
+CON_COMMAND_F(sar_echo_nolf, "sar_echo_nolf <color> <string...> - echo a string to console with a given color and no trailing line feed\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		return console->Print(sar_echo_nolf.ThisPtr()->m_pszHelpString);
 	}


### PR DESCRIPTION
Also wanted to do `sar_hud_order_{top,bottom}`, `sar_ihud_preset`, and `sar_fast_load_preset`, but macro weirdness scared me off (`CON_COMMAND_F_COMPLETION` doesn't seem to like the autocomplete func being defined inline) (obvious now that i actually look at what that does)

Newly unrecorded commands:

- `sar_hud_order_reset`
- `sar_hud_set_text`
- `sar_hud_set_text_color`
- `sar_hud_hide_text`
- `sar_hud_show_text`
- `sar_ihud_setpos` / `sar_lphud_setpos` (`CON_COMMAND_HUD_SETPOS`)
- `sar_toast_setpos`
- `sar_ihud_modify`
- `sar_ihud_add_key`
- `sar_ihud_set_background`
- `sar_ihud_clear_background`
- `sar_toast_tag_set_color`
- `sar_toast_tag_set_duration`
- `sar_toast_tag_dismiss_all`
- `sar_toast_dismiss_all`
- `sar_toast_create`
- `sar_toast_net_create`
- `sar_echo`
- `sar_echo_nolf`