### PR TITLE
feat: allow time for `sar_speedrun_offset`

### DIFF
--- a/src/Features/Speedrun/SpeedrunTimer.hpp
+++ b/src/Features/Speedrun/SpeedrunTimer.hpp
@@ -20,6 +20,7 @@ namespace SpeedrunTimer {
 	void AddPauseTick();
 	void FinishLoad();
 
+	int GetOffsetTicks();
 	int GetSegmentTicks();
 	int GetSplitTicks();
 	int GetTotalTicks();


### PR DESCRIPTION
also unlimit args for `sar_speedrun_recover` so breakset doesn't confuse things