### PR TITLE
feat: Config plus improvements (again...)

### DIFF
--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -133,11 +133,22 @@ DECL_DECLARE_AUTOCOMPLETION_FUNCTION(svar_get) {
 }
 
 CON_COMMAND_F_COMPLETION(svar_set, "svar_set <variable> <value> - set a svar (SAR variable) to a given value\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(svar_set)) {
-	if (args.ArgC() != 3) {
+	if (args.ArgC() < 3) {
 		return console->Print(svar_set.ThisPtr()->m_pszHelpString);
 	}
 
-	SetSvar({args[1]}, {args[2]});
+	const char *cmd;
+
+	if (args.ArgC() == 3) {
+		cmd = args[2];
+	} else {
+		cmd = args.m_pArgSBuffer + args.m_nArgv0Size;
+		while (isspace(*cmd)) ++cmd;
+		cmd += (*cmd == '"') * 2 + strlen(args[1]);
+		while (isspace(*cmd)) ++cmd;
+	}
+
+	SetSvar({args[1]}, {cmd});
 }
 
 CON_COMMAND_F_COMPLETION(svar_substr, "svar_substr <variable> <from> [len] - sets a svar to its substring.\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(svar_get)) {

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -267,9 +267,11 @@ CON_COMMAND_F_COMPLETION(svar_from_cvar, "svar_from_cvar <variable> <cvar> - cap
 	Variable cvar(args[2]);
 
 	if (cvar.ThisPtr()) {
-		std::string val = cvar.GetFlags() & FCVAR_NEVER_AS_STRING ? std::to_string(cvar.GetInt()) : cvar.GetString();
-		val.erase(std::remove(val.begin(), val.end(), '\n'), val.end());
-		SetSvar({args[1]}, val);
+		if (!cvar.ThisPtr()->IsCommand()) {
+			std::string val = cvar.GetFlags() & FCVAR_NEVER_AS_STRING ? std::to_string(cvar.GetInt()) : cvar.GetString();
+			val.erase(std::remove(val.begin(), val.end(), '\n'), val.end());
+			SetSvar({args[1]}, val);
+		}
 	}
 }
 

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -958,7 +958,7 @@ CON_COMMAND_F(sar_function, "sar_function <name> [command] [args]... - create a 
 
 static void expand(const CCommand &args, std::string body) {
 	std::string cmd;
-	unsigned nargs = args.ArgC() - 2;
+	int nargs = args.ArgC() - 2;
 	for (size_t i = 0; i < body.size(); ++i) {
 		if (body[i] == '$') {
 			if (body[i + 1] == '$') {
@@ -976,8 +976,8 @@ static void expand(const CCommand &args, std::string body) {
 				continue;
 			} else if (body[i + 1] == '+') {
 				++i;
-				if (body[i + 1] >= '1' && body[i + 1] <= '9') {
-					unsigned arg = body[i + 1] - '0';
+				if (body[i + 1] >= '0' && body[i + 1] <= '9') {
+					int arg = body[i + 1] - '0';
 					++i;
 					while (body[i + 1] >= '0' && body[i + 1] <= '9') {
 						arg = arg * 10 + (body[i + 1] - '0');
@@ -985,10 +985,10 @@ static void expand(const CCommand &args, std::string body) {
 					}
 					if (arg - 1 < nargs) {
 						// Skip the first n + 1 arguments
-						// (including 'sar_function_run <function>')
+						// (sar_function_run)
 						const char *greedy = args.m_pArgSBuffer + args.m_nArgv0Size;
 						while (isspace(*greedy)) ++greedy;
-						for (unsigned j = 1; j < arg + 1; ++j) {
+						for (int j = 1; j < arg + 1; ++j) {
 							greedy += (*greedy == '"') * 2 + strlen(args[j]);
 							while (isspace(*greedy)) ++greedy;
 						}
@@ -1002,8 +1002,8 @@ static void expand(const CCommand &args, std::string body) {
 				cmd += std::to_string(nargs);
 				++i;
 				continue;
-			} else if (body[i + 1] >= '1' && body[i + 1] <= '9') {
-				unsigned arg = body[i + 1] - '0';
+			} else if (body[i + 1] >= '0' && body[i + 1] <= '9') {
+				int arg = body[i + 1] - '0';
 				++i;
 				while (body[i + 1] >= '0' && body[i + 1] <= '9') {
 					arg = arg * 10 + (body[i + 1] - '0');
@@ -1049,7 +1049,7 @@ CON_COMMAND_F(sar_expand, "sar_expand [cmd]... - run a command after expanding s
 	}
 
 	const char *cmd = args.ArgC() == 2 ? args[1] : args.m_pArgSBuffer + args.m_nArgv0Size;
-	const CCommand noArgs = {2};  // ArgC = 2 means nargs = 0
+	const CCommand noArgs = {1};  // ArgC = 1 means nargs = -1
 	expand(noArgs, std::string(cmd));
 }
 

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -667,23 +667,29 @@ static Condition *ParseCondition(std::queue<Token> toks) {
 
 // }}}
 
-#define MK_SAR_ON(name, when, immediately)                                                                                           \
-	static std::vector<std::string> _g_execs_##name;                                                                                    \
-	CON_COMMAND_F(sar_on_##name, "sar_on_" #name " <command> [args]... - registers a command to be run " when "\n", FCVAR_DONTRECORD) { \
-		if (args.ArgC() < 2) {                                                                                                             \
-			return console->Print(sar_on_##name.ThisPtr()->m_pszHelpString);                                                                  \
-		}                                                                                                                                  \
-		const char *cmd = args.ArgC() == 2 ? args[1] : args.m_pArgSBuffer + args.m_nArgv0Size;                                             \
-		_g_execs_##name.push_back(std::string(cmd));                                                                                       \
-	}                                                                                                                                   \
+#define MK_SAR_ON(name, when, immediately)                                                                                                \
+	static std::vector<std::string> _g_execs_##name;                                                                                         \
+	CON_COMMAND_F(sar_on_##name, "sar_on_" #name " <command> [args]... - registers a command to be run " when "\n", FCVAR_DONTRECORD) {      \
+		if (args.ArgC() < 2) {                                                                                                                  \
+			return console->Print(sar_on_##name.ThisPtr()->m_pszHelpString);                                                                       \
+		}                                                                                                                                       \
+		const char *cmd = args.ArgC() == 2 ? args[1] : args.m_pArgSBuffer + args.m_nArgv0Size;                                                  \
+		_g_execs_##name.push_back(std::string(cmd));                                                                                            \
+	}                                                                                                                                        \
 	CON_COMMAND_F(sar_on_##name##_clear, "sar_on_" #name "_clear - clears commands registered on event \"" #name "\"\n", FCVAR_DONTRECORD) { \
-		console->Print("Cleared %d commands from event \"" #name "\"\n", _g_execs_##name.size());                                  \
-		_g_execs_##name.clear();                                                                                       \
-	}                                                                                                                                   \
-	static void _runExecs_##name() {                                                                                                    \
-		for (auto cmd : _g_execs_##name) {                                                                                                 \
-			engine->ExecuteCommand(cmd.c_str(), immediately);                                                                                 \
-		}                                                                                                                                  \
+		console->Print("Cleared %d commands from event \"" #name "\"\n", _g_execs_##name.size());                                               \
+		_g_execs_##name.clear();                                                                                                                \
+	}                                                                                                                                        \
+	CON_COMMAND_F(sar_on_##name##_list, "sar_on" #name "_list - lists commands registered on event \"" #name "\"\n", FCVAR_DONTRECORD) {     \
+		console->Print("%d commands on event \"" #name "\"\n", _g_execs_##name.size());                                                         \
+		for (auto cmd : _g_execs_##name) {                                                                                                      \
+			console->Print("%s\n", cmd.c_str());                                                                                                   \
+		}                                                                                                                                       \
+	}                                                                                                                                        \
+	static void _runExecs_##name() {                                                                                                         \
+		for (auto cmd : _g_execs_##name) {                                                                                                      \
+			engine->ExecuteCommand(cmd.c_str(), immediately);                                                                                      \
+		}                                                                                                                                       \
 	}
 
 #define RUN_EXECS(x) _runExecs_##x()

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -273,44 +273,67 @@ CON_COMMAND_F_COMPLETION(svar_from_cvar, "svar_from_cvar <variable> <cvar> - cap
 	}
 }
 
-#define SVAR_OP(name, op, disallowSecondZero)                                                                                            \
+#define SVAR_OP(name, op, disallowSecondZero)                      \
 	CON_COMMAND_F_COMPLETION(svar_##name, "svar_" #name " <variable> <variable|value> - perform the given operation on an svar\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(svar_get)) { \
-		if (args.ArgC() != 3) {                                                                                                                \
-			return console->Print(svar_##name.ThisPtr()->m_pszHelpString);                                                                        \
-		}                                                                                                                                      \
-                                                                                                                                         \
-		int cur;                                                                                                                               \
-                                                                                                                                         \
-		{                                                                                                                                      \
-			auto it = g_svars.find({args[1]});                                                                                                    \
-			if (it == g_svars.end()) {                                                                                                            \
-				cur = 0;                                                                                                                             \
-			} else {                                                                                                                              \
-				cur = atoi(it->second.c_str());                                                                                                      \
-			}                                                                                                                                     \
-		}                                                                                                                                      \
-                                                                                                                                         \
-		char *end;                                                                                                                             \
-		int other = strtol(args[2], &end, 10);                                                                                                 \
-                                                                                                                                         \
-		if (end == args[2] || *end) {                                                                                                          \
-			auto it = g_svars.find({args[2]});                                                                                                    \
-			if (it == g_svars.end()) {                                                                                                            \
-				other = 0;                                                                                                                           \
-			} else {                                                                                                                              \
-				other = atoi(it->second.c_str());                                                                                                    \
-			}                                                                                                                                     \
-		}                                                                                                                                      \
-                                                                                                                                         \
-		int val = (disallowSecondZero && other == 0) ? 0 : cur op other;                                                                       \
-		SetSvar({args[1]}, Utils::ssprintf("%d", val));													                                                                           \
+		if (args.ArgC() != 3) {                                          \
+			return console->Print(svar_##name.ThisPtr()->m_pszHelpString);  \
+		}                                                                \
+		int cur;                                                         \
+		{                                                                \
+			auto it = g_svars.find({args[1]});                              \
+			cur = (it == g_svars.end()) ? 0 : atoi(it->second.c_str());     \
+		}                                                                \
+		char *end;                                                       \
+		int other = strtol(args[2], &end, 10);                           \
+		if (end == args[2] || *end) {                                    \
+			auto it = g_svars.find({args[2]});                              \
+			other = (it == g_svars.end()) ? 0 : atoi(it->second.c_str());   \
+		}                                                                \
+		int val = (disallowSecondZero && other == 0) ? 0 : op;           \
+		SetSvar({args[1]}, Utils::ssprintf("%d", val));                  \
+	}                                                                 \
+	                                                                  \
+	CON_COMMAND_F_COMPLETION(svar_f##name, "svar_f" #name " <variable> <variable|value> - perform the given operation on an svar\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(svar_get)) { \
+		if (args.ArgC() != 3) {                                          \
+			return console->Print(svar_f##name.ThisPtr()->m_pszHelpString); \
+		}                                                                \
+		double cur;                                                      \
+		{                                                                \
+			auto it = g_svars.find({args[1]});                              \
+			cur = (it == g_svars.end()) ? 0 : atof(it->second.c_str());     \
+		}                                                                \
+		char *end;                                                       \
+		double other = strtod(args[2], &end);                            \
+		if (end == args[2] || *end) {                                    \
+			auto it = g_svars.find({args[2]});                              \
+			other = (it == g_svars.end()) ? 0 : atof(it->second.c_str());   \
+		}                                                                \
+		double val = (disallowSecondZero && other == 0) ? 0 : op;        \
+		SetSvar({args[1]}, Utils::ssprintf("%g", val));                  \
 	}
 
-SVAR_OP(add, +, false)
-SVAR_OP(sub, -, false)
-SVAR_OP(mul, *, false)
-SVAR_OP(div, /, true)
-SVAR_OP(mod, %, true)
+SVAR_OP(add, cur + other, false)
+SVAR_OP(sub, cur - other, false)
+SVAR_OP(mul, cur * other, false)
+SVAR_OP(div, cur / other, true)
+SVAR_OP(mod, fmod(cur, other), true) // fmod seems to work fine for integers
+
+#define SVAR_SINGLE_OP(name, op)\
+	CON_COMMAND_F_COMPLETION(svar_##name, "svar_" #name " <variable> - perform the given operation on an svar\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(svar_get)) { \
+		if (args.ArgC() != 2) {                                            \
+			return console->Print(svar_##name.ThisPtr()->m_pszHelpString);    \
+		}                                                                  \
+                                                                     \
+		auto it = g_svars.find({args[1]});                                 \
+		double cur = (it == g_svars.end()) ? 0 : atof(it->second.c_str()); \
+                                                                     \
+		SetSvar({args[1]}, Utils::ssprintf("%g", op));                     \
+	}
+
+SVAR_SINGLE_OP(round, round(cur))
+SVAR_SINGLE_OP(floor, floor(cur))
+SVAR_SINGLE_OP(ceil, ceil(cur))
+SVAR_SINGLE_OP(abs, fabs(cur))
 
 struct Condition {
 	enum {


### PR DESCRIPTION
- Primitive svar completion for `svar_get`, `svar_substr`, `svar_[no_]persist`, `svar_capture`, `svar_from_cvar`, and operations
- Remove the single-argument limit on `svar_set` (e.g. `svar_set a b c` => `a = b c`)
- `sar_on_{x}_list` for debugging / curiosity. arguably could add a index to the list and `sar_on_{x}_remove <i>` but that's too fancy
- `$0`/`$+0` in expansion -- quite dubious, feel free to drop but I don't see the harm
- Re-order the code to be feature-contiguous
- Floating point svar math!! Adds `svar_round`, `svar_floor`, `svar_ceil`, and `svar_abs` (the last of which is pretty superfluous)