### PR TITLE
fix: dont record various commands

### DIFF
--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -94,7 +94,8 @@ CON_COMMAND(sar_delete_alias_cmds, "sar_delete_alias_cmds - deletes all alias co
 	}
 }
 
-CON_COMMAND_COMPLETION(sar_fast_load_preset, "sar_fast_load_preset <preset> - sets all loading fixes to preset values\n", ({"none", "sla", "normal", "full"})) {
+DECL_AUTO_COMMAND_COMPLETION(sar_fast_load_preset, ({"none", "sla", "normal", "full"}))
+CON_COMMAND_F_COMPLETION(sar_fast_load_preset, "sar_fast_load_preset <preset> - sets all loading fixes to preset values\n", FCVAR_DONTRECORD, sar_fast_load_preset_CompletionFunc) {
 	if (args.ArgC() != 2) {
 		console->Print(sar_fast_load_preset.ThisPtr()->m_pszHelpString);
 		return;

--- a/src/Features/Cvars.cpp
+++ b/src/Features/Cvars.cpp
@@ -130,7 +130,7 @@ void Cvars::ListAll() {
 }
 void Cvars::PrintHelp(const CCommand &args) {
 	if (args.ArgC() != 2) {
-		return console->Print("Prints help string of cvar. Usage: help <cvar>\n");
+		return console->Print("help <cvar> - prints information about a cvar.\n");
 	}
 
 	auto cmd = reinterpret_cast<ConCommandBase *>(tier1->FindCommandBase(tier1->g_pCVar->ThisPtr(), args[1]));

--- a/src/Features/Hud/Hud.cpp
+++ b/src/Features/Hud/Hud.cpp
@@ -25,16 +25,16 @@
 #	define strcasecmp _stricmp
 #endif
 
-Variable sar_hud_spacing("sar_hud_spacing", "1", 0, "Spacing between elements of HUD.\n");
-Variable sar_hud_x("sar_hud_x", "2", 0, "X padding of HUD.\n");
-Variable sar_hud_y("sar_hud_y", "2", 0, "Y padding of HUD.\n");
-Variable sar_hud_font_index("sar_hud_font_index", "0", 0, "Font index of HUD.\n");
-Variable sar_hud_font_color("sar_hud_font_color", "255 255 255 255", "RGBA font color of HUD.\n", 0);
+Variable sar_hud_spacing("sar_hud_spacing", "1", 0, "Spacing between elements of HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_hud_x("sar_hud_x", "2", 0, "X padding of HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_hud_y("sar_hud_y", "2", 0, "Y padding of HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_hud_font_index("sar_hud_font_index", "0", 0, "Font index of HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_hud_font_color("sar_hud_font_color", "255 255 255 255", "RGBA font color of HUD.\n", FCVAR_DONTRECORD);
 
-Variable sar_hud_precision("sar_hud_precision", "3", 0, "Precision of HUD numbers.\n");
-Variable sar_hud_velocity_precision("sar_hud_velocity_precision", "2", 0, "Precision of velocity HUD numbers.\n");
+Variable sar_hud_precision("sar_hud_precision", "3", 0, "Precision of HUD numbers.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_hud_velocity_precision("sar_hud_velocity_precision", "2", 0, "Precision of velocity HUD numbers.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
 
-Variable sar_hud_rainbow("sar_hud_rainbow", "-1", -1, 1, "Enables the rainbow HUD mode. -1 = default, 0 = disable, 1 = enable.\n");
+Variable sar_hud_rainbow("sar_hud_rainbow", "-1", -1, 1, "Enables the rainbow HUD mode. -1 = default, 0 = disable, 1 = enable.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
 static bool g_rainbow = false;
 ON_INIT {
 	time_t t = time(NULL);
@@ -303,7 +303,10 @@ void HudElement::IndexAll() {
 
 // Commands
 
-CON_COMMAND_COMPLETION(sar_hud_order_top, "sar_hud_order_top <name> - orders hud element to top\n", (elementOrder)) {
+DECL_AUTO_COMMAND_COMPLETION(sar_hud_order_top, (elementOrder))
+DECL_AUTO_COMMAND_COMPLETION(sar_hud_order_bottom, (elementOrder))
+
+CON_COMMAND_F_COMPLETION(sar_hud_order_top, "sar_hud_order_top <name> - orders hud element to top\n", FCVAR_DONTRECORD, sar_hud_order_top_CompletionFunc) {
 	if (args.ArgC() != 2) {
 		return console->Print("Orders hud element to top: sar_hud_order_top <name>\n");
 	}
@@ -329,7 +332,7 @@ CON_COMMAND_COMPLETION(sar_hud_order_top, "sar_hud_order_top <name> - orders hud
 
 	console->Print("Moved HUD element %s to top.\n", args[1]);
 }
-CON_COMMAND_COMPLETION(sar_hud_order_bottom, "sar_hud_order_bottom <name> - orders hud element to bottom\n", (elementOrder)) {
+CON_COMMAND_F_COMPLETION(sar_hud_order_bottom, "sar_hud_order_bottom <name> - orders hud element to bottom\n", FCVAR_DONTRECORD, sar_hud_order_bottom_CompletionFunc) {
 	if (args.ArgC() != 2) {
 		return console->Print("Set!\n");
 	}
@@ -355,7 +358,7 @@ CON_COMMAND_COMPLETION(sar_hud_order_bottom, "sar_hud_order_bottom <name> - orde
 
 	console->Print("Moved HUD element %s to bottom.\n", args[1]);
 }
-CON_COMMAND(sar_hud_order_reset, "sar_hud_order_reset - resets order of hud element\n") {
+CON_COMMAND_F(sar_hud_order_reset, "sar_hud_order_reset - resets order of hud elements\n", FCVAR_DONTRECORD) {
 	std::sort(vgui->elements.begin(), vgui->elements.end(), [](const HudElement *a, const HudElement *b) {
 		return a->orderIndex < b->orderIndex;
 	});
@@ -398,7 +401,7 @@ HUD_ELEMENT2_NO_DISABLE(text, HudType_InGame | HudType_Paused | HudType_Menu | H
 	}
 }
 
-Variable sar_hud_text("sar_hud_text", "", "DEPRECATED: Use sar_hud_set_text.\n", 0);
+Variable sar_hud_text("sar_hud_text", "", "DEPRECATED: Use sar_hud_set_text.\n", FCVAR_DONTRECORD);
 void sar_hud_text_callback(void *var, const char *pOldVal, float fOldVal) {
 	console->Print("WARNING: sar_hud_text is deprecated. Please use sar_hud_set_text instead.\n");
 	sar_hud_text_vals[0].draw = sar_hud_text.GetString()[0];
@@ -480,7 +483,7 @@ long parseIdx(const char *idxStr) {
 	return idx;
 }
 
-CON_COMMAND(sar_hud_set_text, "sar_hud_set_text <id> <text>... - sets and shows the nth text value in the HUD\n") {
+CON_COMMAND_F(sar_hud_set_text, "sar_hud_set_text <id> <text>... - sets and shows the nth text value in the HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 3) {
 		console->Print(sar_hud_set_text.ThisPtr()->m_pszHelpString);
 		return;
@@ -549,7 +552,7 @@ CON_COMMAND(sar_hud_set_text, "sar_hud_set_text <id> <text>... - sets and shows 
 	sar_hud_text_vals[idx].components = components;
 }
 
-CON_COMMAND(sar_hud_set_text_color, "sar_hud_set_text_color <id> [color] - sets the color of the nth text value in the HUD. Reset by not giving color.\n") {
+CON_COMMAND_F(sar_hud_set_text_color, "sar_hud_set_text_color <id> [color] - sets the color of the nth text value in the HUD. Reset by not giving color.\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2 || args.ArgC() > 3) {
 		console->Print(sar_hud_set_text_color.ThisPtr()->m_pszHelpString);
 		return;
@@ -570,7 +573,7 @@ CON_COMMAND(sar_hud_set_text_color, "sar_hud_set_text_color <id> [color] - sets 
 	}
 }
 
-CON_COMMAND(sar_hud_hide_text, "sar_hud_hide_text <id> - hides the nth text value in the HUD\n") {
+CON_COMMAND_F(sar_hud_hide_text, "sar_hud_hide_text <id> - hides the nth text value in the HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		console->Print(sar_hud_hide_text.ThisPtr()->m_pszHelpString);
 		return;
@@ -585,7 +588,7 @@ CON_COMMAND(sar_hud_hide_text, "sar_hud_hide_text <id> - hides the nth text valu
 	sar_hud_text_vals[idx].draw = false;
 }
 
-CON_COMMAND(sar_hud_show_text, "sar_hud_show_text <id> - shows the nth text value in the HUD\n") {
+CON_COMMAND_F(sar_hud_show_text, "sar_hud_show_text <id> - shows the nth text value in the HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		console->Print(sar_hud_show_text.ThisPtr()->m_pszHelpString);
 		return;

--- a/src/Features/Hud/Hud.hpp
+++ b/src/Features/Hud/Hud.hpp
@@ -111,17 +111,17 @@ public:
 	HudElement sar_hud_element_##name("sar_hud_" #name, sar_hud_element_##name##_callback, type); \
 	void sar_hud_element_##name##_callback(HudContext *ctx)
 #define HUD_ELEMENT(name, value, desc, type)                                                  \
-	Variable sar_hud_##name("sar_hud_" #name, value, desc);                                      \
+	Variable sar_hud_##name("sar_hud_" #name, value, desc, FCVAR_DONTRECORD);                    \
 	void sar_hud_element_##name##_callback(HudContext *ctx);                                     \
 	HudElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type); \
 	void sar_hud_element_##name##_callback(HudContext *ctx)
 #define HUD_ELEMENT_STRING(name, value, desc, type)                                                 \
-	Variable sar_hud_##name("sar_hud_" #name, value, desc, 0);                                         \
+	Variable sar_hud_##name("sar_hud_" #name, value, desc, FCVAR_DONTRECORD);                          \
 	void sar_hud_element_##name##_callback(HudContext *ctx, const char *text);                         \
 	HudStringElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type); \
 	void sar_hud_element_##name##_callback(HudContext *ctx, const char *text)
 #define HUD_ELEMENT_MODE(name, value, min, max, desc, type)                                       \
-	Variable sar_hud_##name("sar_hud_" #name, value, min, max, desc);                                \
+	Variable sar_hud_##name("sar_hud_" #name, value, min, max, desc, FCVAR_DONTRECORD);              \
 	void sar_hud_element_##name##_callback(HudContext *ctx, int mode);                               \
 	HudModeElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type); \
 	void sar_hud_element_##name##_callback(HudContext *ctx, int mode)
@@ -131,33 +131,33 @@ public:
 	HudElement sar_hud_element_##name("sar_hud_" #name, sar_hud_element_##name##_callback, type, true); \
 	void sar_hud_element_##name##_callback(HudContext *ctx)
 #define HUD_ELEMENT2(name, value, desc, type)                                                       \
-	Variable sar_hud_##name("sar_hud_" #name, value, desc);                                            \
+	Variable sar_hud_##name("sar_hud_" #name, value, desc, FCVAR_DONTRECORD);                          \
 	void sar_hud_element_##name##_callback(HudContext *ctx);                                           \
 	HudElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type, true); \
 	void sar_hud_element_##name##_callback(HudContext *ctx)
 #define HUD_ELEMENT_STRING2(name, value, desc, type)                                                      \
-	Variable sar_hud_##name("sar_hud_" #name, value, desc, 0);                                               \
+	Variable sar_hud_##name("sar_hud_" #name, value, desc, FCVAR_DONTRECORD);                                \
 	void sar_hud_element_##name##_callback(HudContext *ctx, const char *text);                               \
 	HudStringElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type, true); \
 	void sar_hud_element_##name##_callback(HudContext *ctx, const char *text)
 #define HUD_ELEMENT_MODE2(name, value, min, max, desc, type)                                            \
-	Variable sar_hud_##name("sar_hud_" #name, value, min, max, desc);                                      \
+	Variable sar_hud_##name("sar_hud_" #name, value, min, max, desc, FCVAR_DONTRECORD);                    \
 	void sar_hud_element_##name##_callback(HudContext *ctx, int mode);                                     \
 	HudModeElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type, true); \
 	void sar_hud_element_##name##_callback(HudContext *ctx, int mode)
 // Specify game version
 #define HUD_ELEMENT3(name, value, desc, type, showOnSecondScreen, version)                                                 \
-	Variable sar_hud_##name("sar_hud_" #name, value, desc);                                                                   \
+	Variable sar_hud_##name("sar_hud_" #name, value, desc, FCVAR_DONTRECORD);                                                 \
 	void sar_hud_element_##name##_callback(HudContext *ctx);                                                                  \
 	HudElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type, showOnSecondScreen, version); \
 	void sar_hud_element_##name##_callback(HudContext *ctx)
 #define HUD_ELEMENT_STRING3(name, value, desc, type, showOnSecondScreen, version)                                                \
-	Variable sar_hud_##name("sar_hud_" #name, value, desc, 0);                                                                      \
+	Variable sar_hud_##name("sar_hud_" #name, value, desc, FCVAR_DONTRECORD);                                                       \
 	void sar_hud_element_##name##_callback(HudContext *ctx, const char *text);                                                      \
 	HudStringElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type, showOnSecondScreen, version); \
 	void sar_hud_element_##name##_callback(HudContext *ctx, const char *text)
 #define HUD_ELEMENT_MODE3(name, value, min, max, desc, type, showOnSecondScreen, version)                                      \
-	Variable sar_hud_##name("sar_hud_" #name, value, min, max, desc);                                                             \
+	Variable sar_hud_##name("sar_hud_" #name, value, min, max, desc, FCVAR_DONTRECORD);                                           \
 	void sar_hud_element_##name##_callback(HudContext *ctx, int mode);                                                            \
 	HudModeElement sar_hud_element_##name(&sar_hud_##name, sar_hud_element_##name##_callback, type, showOnSecondScreen, version); \
 	void sar_hud_element_##name##_callback(HudContext *ctx, int mode)
@@ -177,12 +177,11 @@ int HudSetPos_CompleteFunc(const char *partial, char commands[COMMAND_COMPLETION
 
 #define CON_COMMAND_HUD_SETPOS(name, helpname) \
     CON_COMMAND_F_COMPLETION( \
-        name##_setpos,                                                                              \
-        "Automatically sets the position of " helpname ".\n"                                          \
-        "Usage: " #name "_setpos <top|center|bottom|y|y\%> <left|center|right|x|x\%>\n",              \
-        0, HudSetPos_CompleteFunc                                                                     \
-    ) {                                                                                               \
-        if (args.ArgC() != 3) return console->Print(name##_setpos.ThisPtr()->m_pszHelpString);      \
-        name##_x.SetValue(args[2]);                                                                 \
-        name##_y.SetValue(args[1]);                                                                 \
+        name##_setpos,                                                                                                            \
+        #name "_setpos <top|center|bottom|y|y\%> <left|center|right|x|x\%> - automatically sets the position of " helpname ".\n", \
+        FCVAR_DONTRECORD, HudSetPos_CompleteFunc                                                                                  \
+    ) {                                                                                                                           \
+        if (args.ArgC() != 3) return console->Print(name##_setpos.ThisPtr()->m_pszHelpString);                                    \
+        name##_x.SetValue(args[2]);                                                                                               \
+        name##_y.SetValue(args[1]);                                                                                               \
 	}

--- a/src/Features/Hud/InputHud.cpp
+++ b/src/Features/Hud/InputHud.cpp
@@ -12,13 +12,13 @@
 #include <cstring>
 #include <sstream>
 
-Variable sar_ihud("sar_ihud", "0", 0, 1, "Enables or disables movement inputs HUD of client.\n");
-Variable sar_ihud_x("sar_ihud_x", "2", "X position of input HUD.\n", 0);
-Variable sar_ihud_y("sar_ihud_y", "2", "Y position of input HUD.\n", 0);
-Variable sar_ihud_grid_padding("sar_ihud_grid_padding", "2", 0, "Padding between grid squares of input HUD.\n");
-Variable sar_ihud_grid_size("sar_ihud_grid_size", "60", 0, "Grid square size of input HUD.\n");
-Variable sar_ihud_analog_image_scale("sar_ihud_analog_image_scale", "0.6", 0, 1, "Scale of analog input images against max extent.\n");
-Variable sar_ihud_analog_view_deshake("sar_ihud_analog_view_deshake", "0", "Try to eliminate small fluctuations in the movement analog.\n");
+Variable sar_ihud("sar_ihud", "0", 0, 1, "Enables or disables movement inputs HUD of client.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_ihud_x("sar_ihud_x", "2", "X position of input HUD.\n", FCVAR_DONTRECORD);
+Variable sar_ihud_y("sar_ihud_y", "2", "Y position of input HUD.\n", FCVAR_DONTRECORD);
+Variable sar_ihud_grid_padding("sar_ihud_grid_padding", "2", 0, "Padding between grid squares of input HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_ihud_grid_size("sar_ihud_grid_size", "60", 0, "Grid square size of input HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_ihud_analog_image_scale("sar_ihud_analog_image_scale", "0.6", 0, 1, "Scale of analog input images against max extent.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_ihud_analog_view_deshake("sar_ihud_analog_view_deshake", "0", "Try to eliminate small fluctuations in the movement analog.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
 
 InputHud inputHud;
 
@@ -559,8 +559,8 @@ void InputHud::AddElement(std::string name, int type) {
 	});
 }
 
-
-CON_COMMAND_COMPLETION(sar_ihud_preset, "sar_ihud_preset <preset> - modifies input hud based on given preset\n", ({"normal", "normal_mouse", "tas"})) {
+DECL_AUTO_COMMAND_COMPLETION(sar_ihud_preset, ({"normal", "normal_mouse", "tas"}))
+CON_COMMAND_F_COMPLETION(sar_ihud_preset, "sar_ihud_preset <preset> - modifies input hud based on given preset\n", FCVAR_DONTRECORD, sar_ihud_preset_CompletionFunc) {
 	if (args.ArgC() != 2) {
 		console->Print(sar_ihud_preset.ThisPtr()->m_pszHelpString);
 		return;
@@ -595,7 +595,7 @@ DECL_COMMAND_COMPLETION(sar_ihud_modify) {
 CON_COMMAND_F_COMPLETION(sar_ihud_modify,
 	"sar_ihud_modify <element|all> [param=value]... - modifies parameters in given element.\n"
     "Params: enabled, text, pos, x, y, width, height, font, background, highlight, textcolor, texthighlight, image, highlightimage, minhold.\n",
-	0, sar_ihud_modify_CompletionFunc
+	FCVAR_DONTRECORD, sar_ihud_modify_CompletionFunc
 ) {
 	if (args.ArgC() < 3) {
 		console->Print(sar_ihud_modify.ThisPtr()->m_pszHelpString);
@@ -661,7 +661,7 @@ CON_COMMAND_F_COMPLETION(sar_ihud_modify,
 	}
 }
 
-CON_COMMAND(sar_ihud_add_key, "sar_ihud_add_key <key>\n") {
+CON_COMMAND_F(sar_ihud_add_key, "sar_ihud_add_key <key>\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		console->Print(sar_ihud_add_key.ThisPtr()->m_pszHelpString);
 		return;
@@ -683,7 +683,7 @@ CON_COMMAND(sar_ihud_add_key, "sar_ihud_add_key <key>\n") {
 
 CON_COMMAND_HUD_SETPOS(sar_ihud, "input HUD")
 
-CON_COMMAND(sar_ihud_set_background, "sar_ihud_set_background <path> <grid x> <grid y> <grid w> <grid h>\n") {
+CON_COMMAND_F(sar_ihud_set_background, "sar_ihud_set_background <path> <grid x> <grid y> <grid w> <grid h>\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 6) {
 		console->Print(sar_ihud_set_background.ThisPtr()->m_pszHelpString);
 		return;
@@ -707,6 +707,6 @@ CON_COMMAND(sar_ihud_set_background, "sar_ihud_set_background <path> <grid x> <g
 	inputHud.bgGridH = atoi(args[5]);
 }
 
-CON_COMMAND(sar_ihud_clear_background, "sar_ihud_clear_background\n") {
+CON_COMMAND_F(sar_ihud_clear_background, "sar_ihud_clear_background\n", FCVAR_DONTRECORD) {
 	inputHud.bgTextureId = -1;
 }

--- a/src/Features/Hud/SpeedrunHud.cpp
+++ b/src/Features/Hud/SpeedrunHud.cpp
@@ -6,11 +6,11 @@
 #include "Modules/Surface.hpp"
 #include "Variable.hpp"
 
-Variable sar_sr_hud("sar_sr_hud", "0", 0, "Draws speedrun timer.\n");
-Variable sar_sr_hud_x("sar_sr_hud_x", "0", "X offset of speedrun timer HUD.\n", 0);
-Variable sar_sr_hud_y("sar_sr_hud_y", "100", "Y offset of speedrun timer HUD.\n", 0);
-Variable sar_sr_hud_font_color("sar_sr_hud_font_color", "255 255 255 255", "RGBA font color of speedrun timer HUD.\n", 0);
-Variable sar_sr_hud_font_index("sar_sr_hud_font_index", "70", 0, "Font index of speedrun timer HUD.\n");
+Variable sar_sr_hud("sar_sr_hud", "0", 0, "Draws speedrun timer.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_sr_hud_x("sar_sr_hud_x", "0", "X offset of speedrun timer HUD.\n", FCVAR_DONTRECORD);
+Variable sar_sr_hud_y("sar_sr_hud_y", "100", "Y offset of speedrun timer HUD.\n", FCVAR_DONTRECORD);
+Variable sar_sr_hud_font_color("sar_sr_hud_font_color", "255 255 255 255", "RGBA font color of speedrun timer HUD.\n", FCVAR_DONTRECORD);
+Variable sar_sr_hud_font_index("sar_sr_hud_font_index", "70", 0, "Font index of speedrun timer HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
 
 SpeedrunHud speedrunHud;
 

--- a/src/Features/Hud/Toasts.cpp
+++ b/src/Features/Hud/Toasts.cpp
@@ -54,16 +54,16 @@ static int g_slideOff;
 #define STR(s) #s
 #define EXP_STR(s) STR(s)
 
-Variable sar_toast_disable("sar_toast_disable", "0", "Disable all toasts from showing.\n");
-Variable sar_toast_font("sar_toast_font", "6", 0, "The font index to use for toasts.\n");
-Variable sar_toast_width("sar_toast_width", "250", 2 * SIDE_PAD + 10, "The maximum width for toasts.\n");
-Variable sar_toast_x("sar_toast_x", EXP_STR(TOAST_GAP), 0, "The horizontal position of the toasts HUD.\n");
-Variable sar_toast_y("sar_toast_y", EXP_STR(TOAST_GAP), 0, "The vertical position of the toasts HUD.\n");
-Variable sar_toast_align("sar_toast_align", "0", 0, 2, "The side to align toasts to horizontally. 0 = left, 1 = center, 2 = right.\n");
-Variable sar_toast_anchor("sar_toast_anchor", "1", 0, 1, "Where to put new toasts. 0 = bottom, 1 = top.\n");
-Variable sar_toast_compact("sar_toast_compact", "0", "Enables a compact form of the toasts HUD.\n");
-Variable sar_toast_background("sar_toast_background", "1", 0, 2, "Sets the background highlight for toasts. 0 = no background, 1 = text width only, 2 = full width.\n");
-Variable sar_toast_net_disable("sar_toast_net_disable", "0", "Disable network toasts.\n");
+Variable sar_toast_disable("sar_toast_disable", "0", "Disable all toasts from showing.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_font("sar_toast_font", "6", 0, "The font index to use for toasts.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_width("sar_toast_width", "250", 2 * SIDE_PAD + 10, "The maximum width for toasts.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_x("sar_toast_x", EXP_STR(TOAST_GAP), 0, "The horizontal position of the toasts HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_y("sar_toast_y", EXP_STR(TOAST_GAP), 0, "The vertical position of the toasts HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_align("sar_toast_align", "0", 0, 2, "The side to align toasts to horizontally. 0 = left, 1 = center, 2 = right.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_anchor("sar_toast_anchor", "1", 0, 1, "Where to put new toasts. 0 = bottom, 1 = top.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_compact("sar_toast_compact", "0", "Enables a compact form of the toasts HUD.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_background("sar_toast_background", "1", 0, 2, "Sets the background highlight for toasts. 0 = no background, 1 = text width only, 2 = full width.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_toast_net_disable("sar_toast_net_disable", "0", "Disable network toasts.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
 
 struct TagInfo {
 	uint8_t r, g, b;
@@ -87,7 +87,7 @@ static TagInfo getTagInfo(std::string tag) {
 	};
 }
 
-CON_COMMAND(sar_toast_tag_set_color, "sar_toast_tag_set_color <tag> <color> - set the color of the specified toast tag to an sRGB color\n") {
+CON_COMMAND_F(sar_toast_tag_set_color, "sar_toast_tag_set_color <tag> <color> - set the color of the specified toast tag to an sRGB color\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3 && args.ArgC() != 5) {
 		return console->Print(sar_toast_tag_set_color.ThisPtr()->m_pszHelpString);
 	}
@@ -132,7 +132,7 @@ CON_COMMAND(sar_toast_tag_set_color, "sar_toast_tag_set_color <tag> <color> - se
 	g_tags[tag] = info;
 }
 
-CON_COMMAND(sar_toast_tag_set_duration, "sar_toast_tag_set_duration <tag> <duration> - set the duration of the specified toast tag in seconds. The duration may be given as 'forever'\n") {
+CON_COMMAND_F(sar_toast_tag_set_duration, "sar_toast_tag_set_duration <tag> <duration> - set the duration of the specified toast tag in seconds. The duration may be given as 'forever'\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3) {
 		return console->Print(sar_toast_tag_set_duration.ThisPtr()->m_pszHelpString);
 	}
@@ -157,7 +157,7 @@ CON_COMMAND(sar_toast_tag_set_duration, "sar_toast_tag_set_duration <tag> <durat
 	g_tags[tag] = info;
 }
 
-CON_COMMAND(sar_toast_tag_dismiss_all, "sar_toast_tag_dismiss_all <tag> - dismiss all active toasts with the given tag\n") {
+CON_COMMAND_F(sar_toast_tag_dismiss_all, "sar_toast_tag_dismiss_all <tag> - dismiss all active toasts with the given tag\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 2) {
 		return console->Print(sar_toast_tag_dismiss_all.ThisPtr()->m_pszHelpString);
 	}
@@ -174,7 +174,7 @@ CON_COMMAND(sar_toast_tag_dismiss_all, "sar_toast_tag_dismiss_all <tag> - dismis
 		g_toasts.end());
 }
 
-CON_COMMAND(sar_toast_setpos, "sar_toast_setpos <bottom|top> <left|center|right> - set the position of the toasts HUD\n") {
+CON_COMMAND_F(sar_toast_setpos, "sar_toast_setpos <bottom|top> <left|center|right> - set the position of the toasts HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3) {
 		return console->Print(sar_toast_setpos.ThisPtr()->m_pszHelpString);
 	}
@@ -450,7 +450,7 @@ void ToastHud::Paint(int slot) {
 	}
 }
 
-CON_COMMAND(sar_toast_create, "sar_toast_create <tag> <text> - create a toast\n") {
+CON_COMMAND_F(sar_toast_create, "sar_toast_create <tag> <text> - create a toast\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3) {
 		console->Print(sar_toast_create.ThisPtr()->m_pszHelpString);
 		return;
@@ -459,7 +459,7 @@ CON_COMMAND(sar_toast_create, "sar_toast_create <tag> <text> - create a toast\n"
 	toastHud.AddToast(args[1], args[2]);
 }
 
-CON_COMMAND(sar_toast_net_create, "sar_toast_net_create <tag> <text> - create a toast, also sending it to your coop partner\n") {
+CON_COMMAND_F(sar_toast_net_create, "sar_toast_net_create <tag> <text> - create a toast, also sending it to your coop partner\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() != 3) {
 		console->Print(sar_toast_net_create.ThisPtr()->m_pszHelpString);
 		return;
@@ -484,7 +484,7 @@ CON_COMMAND(sar_toast_net_create, "sar_toast_net_create <tag> <text> - create a 
 	}
 }
 
-CON_COMMAND(sar_toast_dismiss_all, "sar_toast_dismiss_all - dismiss all active toasts\n") {
+CON_COMMAND_F(sar_toast_dismiss_all, "sar_toast_dismiss_all - dismiss all active toasts\n", FCVAR_DONTRECORD) {
 	g_toasts.clear();
 }
 

--- a/src/Modules/Console.cpp
+++ b/src/Modules/Console.cpp
@@ -45,7 +45,7 @@ ConsoleListener::~ConsoleListener() {
 
 Console *console;
 
-CON_COMMAND(sar_echo, "sar_echo <color> <string...> - echo a string to console with a given color\n") {
+CON_COMMAND_F(sar_echo, "sar_echo <color> <string...> - echo a string to console with a given color\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		return console->Print(sar_echo.ThisPtr()->m_pszHelpString);
 	}
@@ -68,7 +68,7 @@ CON_COMMAND(sar_echo, "sar_echo <color> <string...> - echo a string to console w
 	console->ColorMsg(*col, "%s\n", str);
 }
 
-CON_COMMAND(sar_echo_nolf, "sar_echo_nolf <color> <string...> - echo a string to console with a given color and no trailing line feed\n") {
+CON_COMMAND_F(sar_echo_nolf, "sar_echo_nolf <color> <string...> - echo a string to console with a given color and no trailing line feed\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		return console->Print(sar_echo_nolf.ThisPtr()->m_pszHelpString);
 	}

--- a/src/Modules/VGui.cpp
+++ b/src/Modules/VGui.cpp
@@ -14,8 +14,8 @@
 REDECL(VGui::Paint);
 REDECL(VGui::UpdateProgressBar);
 
-Variable sar_hud_bg("sar_hud_bg", "0", "Enable the SAR HUD background.\n");
-Variable sar_hud_orange_only("sar_hud_orange_only", "0", "Only display the SAR HUD for orange, for solo coop (fullscreen PIP).\n");
+Variable sar_hud_bg("sar_hud_bg", "0", "Enable the SAR HUD background.\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
+Variable sar_hud_orange_only("sar_hud_orange_only", "0", "Only display the SAR HUD for orange, for solo coop (fullscreen PIP).\n", FCVAR_NEVER_AS_STRING | FCVAR_DONTRECORD);
 
 void VGui::Draw(Hud *const &hud) {
 	if (hud->ShouldDraw()) {

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -35,7 +35,7 @@ Variable::Variable(const char *name)
 // Boolean or String
 Variable::Variable(const char *name, const char *value, const char *helpstr, int flags, FnChangeCallback_t callback)
 	: Variable() {
-	if (flags != 0)
+	if ((flags & ~FCVAR_DONTRECORD) != 0)
 		Create(name, value, flags, helpstr, true, 0, true, 1, callback);
 	else
 		Create(name, value, flags, helpstr, false, 0, false, 0, callback);


### PR DESCRIPTION
When was the last time someone used `sar_hud_inspection`? Is it worth cheat-protecting? Certainly looks quite cheaty

Newly unrecorded commands:
- `sar_fast_load_preset`
- `sar_hud_*`
- `sar_ihud_*`
- `sar_toast_*`
- `sar_sr_hud_*`
- `sar_echo[_nolf]`

Modified help strings for:
- `help`
- `sar_<x>_setpos`
- `sar_hud_order_reset`

LMK if there's anything else that deserves not recording :)