### PR TITLE
env_projectedtexture fix

### DIFF
--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -1,5 +1,6 @@
 #include "Cheats.hpp"
 
+#include "Event.hpp"
 #include "Features/Cvars.hpp"
 #include "Features/Hud/Hud.hpp"
 #include "Features/Hud/InspectionHud.hpp"
@@ -18,7 +19,6 @@
 #include "Modules/Engine.hpp"
 #include "Modules/Server.hpp"
 #include "Offsets.hpp"
-#include "Event.hpp"
 
 #include <cstring>
 
@@ -51,6 +51,7 @@ Variable ui_transition_effect;
 Variable ui_transition_time;
 Variable hide_gun_when_holding;
 Variable cl_viewmodelfov;
+Variable r_flashlightbrightness;
 
 // P2 only
 CON_COMMAND(sar_togglewait, "sar_togglewait - enables or disables \"wait\" for the command buffer\n") {
@@ -279,6 +280,7 @@ void Cheats::Init() {
 	ui_transition_time = Variable("ui_transition_time");
 	hide_gun_when_holding = Variable("hide_gun_when_holding");
 	cl_viewmodelfov = Variable("cl_viewmodelfov");
+	r_flashlightbrightness = Variable("r_flashlightbrightness");
 
 	sar_disable_challenge_stats_hud.UniqueFor(SourceGame_Portal2);
 
@@ -340,11 +342,10 @@ ON_EVENT(PROCESS_MOVEMENT) {
 	if (!tbeamHandle || (uint32_t)tbeamHandle == (unsigned)Offsets::INVALID_EHANDLE_INDEX) return;
 
 	for (int i = 0; i < 2; i++) {
-		int hitboxOffset = i==0 ? Offsets::m_pShadowCrouch : Offsets::m_pShadowStand;
+		int hitboxOffset = i == 0 ? Offsets::m_pShadowCrouch : Offsets::m_pShadowStand;
 		auto shadow = *reinterpret_cast<void **>((uintptr_t)player + hitboxOffset);
 
 		// WAKE UP YOU MORON YOU'RE RUINING MY FUNNELS ARGGHHH
 		Memory::VMT<void(__rescall *)(void *)>(shadow, Offsets::Wake)(shadow);
 	}
-
 }

--- a/src/Cheats.hpp
+++ b/src/Cheats.hpp
@@ -35,5 +35,6 @@ extern Variable ui_transition_effect;
 extern Variable ui_transition_time;
 extern Variable hide_gun_when_holding;
 extern Variable cl_viewmodelfov;
+extern Variable r_flashlightbrightness;
 
 extern Command sar_togglewait;

--- a/src/Features/Cvars.cpp
+++ b/src/Features/Cvars.cpp
@@ -171,6 +171,7 @@ void Cvars::Lock() {
 		ui_transition_time.Lock();
 		hide_gun_when_holding.Lock();
 		cl_viewmodelfov.Lock();
+		r_flashlightbrightness.Lock();
 
 		this->locked = true;
 	}
@@ -196,6 +197,8 @@ void Cvars::Unlock() {
 		ui_transition_time.Unlock(false);
 		hide_gun_when_holding.Unlock(false);
 		cl_viewmodelfov.Unlock(false);
+		r_flashlightbrightness.Unlock(false);
+		r_flashlightbrightness.RemoveFlag(FCVAR_CHEAT);
 
 		this->locked = false;
 	}


### PR DESCRIPTION
unprotecting a command (r_flashlightbrightness) that should not be protected anyways
i think it gets changed by the map normally (?) but its cheat protected in cm
feat: makes game look better (and how it should be)

default look (non cm) (fixed cm look)
![fix](https://user-images.githubusercontent.com/33593734/191026301-0ac32979-3ff5-4a79-9aa9-1358acc10bd5.png)

default cm look
![nofix](https://user-images.githubusercontent.com/33593734/191026337-4b829f17-6a1b-4449-8309-e33872e0cd84.png)