### PR TITLE
fix: allow `sar_ent_slot_serial` ingame

### DIFF
--- a/src/Features/EntityList.hpp
+++ b/src/Features/EntityList.hpp
@@ -2,6 +2,7 @@
 #include "Command.hpp"
 #include "Feature.hpp"
 #include "Utils.hpp"
+#include <deque>
 
 class EntityList : public Feature {
 public:
@@ -12,8 +13,15 @@ public:
 	IHandleEntity *LookupEntity(const CBaseHandle &handle);
 };
 
+struct EntitySlotSerial {
+	bool done = false;
+	int slot = -1;
+	int serial = -1;
+};
+
 extern EntityList *entityList;
 
 extern Command sar_list_ents;
 extern Command sar_find_ent;
 extern Command sar_find_ents;
+extern std::deque<EntitySlotSerial> g_ent_slot_serial;

--- a/src/Modules/EngineDemoPlayer.cpp
+++ b/src/Modules/EngineDemoPlayer.cpp
@@ -165,6 +165,7 @@ std::string EngineDemoPlayer::GetLevelName() {
 // 0x0B: timestamp (UTC)
 // 0x0C: file checksum
 // 0x0D: 'hwait' run
+// 0x0E: entity slot serial changed
 void EngineDemoPlayer::CustomDemoData(char *data, size_t length) {
 	if (data[0] == 0x03 || data[0] == 0x04) {  // Entity input data
 		std::optional<int> slot;


### PR DESCRIPTION
This PR patches `sar_ent_slot_serial` to change the slot's serial number **the next time the slot is removed** if it can't do it immediately.
Possible problems:
 - The slot is removed more than once, hence making the serial number too high
 - The slot isn't removed on every load, making the behavior unpredictable