### PR TITLE
feat: legacy mtriggers + some spice

### DIFF
--- a/src/Features/Speedrun/Categories.cpp
+++ b/src/Features/Speedrun/Categories.cpp
@@ -231,6 +231,10 @@ std::vector<std::string> SpeedrunTimer::GetCategoryRules() {
 	return g_categories[g_currentCategory].rules;
 }
 
+std::string SpeedrunTimer::GetCategoryName() {
+	return g_currentCategory;
+}
+
 void SpeedrunTimer::ResetCategory() {
 	for (std::string ruleName : g_categories[g_currentCategory].rules) {
 		auto rule = SpeedrunTimer::GetRule(ruleName);

--- a/src/Features/Speedrun/Categories.hpp
+++ b/src/Features/Speedrun/Categories.hpp
@@ -26,6 +26,7 @@ namespace SpeedrunTimer {
 	bool AddRuleToCategory(std::string category, std::string rule);
 	bool CreateRule(std::string name, std::string type, std::map<std::string, std::string> params);
 	std::vector<std::string> GetCategoryRules();
+	std::string GetCategoryName();
 };  // namespace SpeedrunTimer
 
 extern Command sar_speedrun_category;

--- a/src/Features/Speedrun/SpeedrunTimer.hpp
+++ b/src/Features/Speedrun/SpeedrunTimer.hpp
@@ -45,6 +45,8 @@ extern Variable sar_speedrun_start_on_load;
 extern Variable sar_speedrun_offset;
 extern Variable sar_speedrun_autostop;
 
+extern Variable sar_mtrigger_legacy;
+
 extern Command sar_speedrun_start;
 extern Command sar_speedrun_stop;
 extern Command sar_speedrun_split;
@@ -53,3 +55,6 @@ extern Command sar_speedrun_resume;
 extern Command sar_speedrun_reset;
 extern Command sar_speedrun_result;
 extern Command sar_speedrun_export;
+
+extern Command sar_mtrigger_legacy_format;
+extern Command sar_mtrigger_legacy_textcolor;

--- a/src/Modules/Client.cpp
+++ b/src/Modules/Client.cpp
@@ -447,7 +447,7 @@ DETOUR(Client::ProcessMovement, void *player, CMoveData *move) {
 }
 
 CON_COMMAND(sar_chat, "sar_chat - open the chat HUD\n") {
-	if (engine->IsCoop()) client->OpenChat();
+	client->OpenChat();
 }
 
 extern Hook g_DrawTranslucentRenderablesHook;


### PR DESCRIPTION
optional legacy (chat) mtriggers
advantage: being able to just open chat and see previous run's mtriggers
some pros asked for this

spice:
-changable formatting using keywords (!map, !seg, !tt, !st)*
eg sar_mtrigger_legacy_format "!seg -> !tt (!st)" will result in something like "Portal Trigger -> 6.567 (1.333)"
*tt being total time
*st being split time
-changable text color