### PR TITLE
feat: yet more config+ improvements

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -357,7 +357,7 @@ DECL_COMMAND_COMPLETION(sar_workshop)
     FINISH_COMMAND_COMPLETION();
 }
 
-CON_COMMAND_F_COMPLETION(sar_workshop, "Description.\n", 0, sar_workshop_CompletionFunc)
+CON_COMMAND_F_COMPLETION(sar_workshop, "Description.\n", 0, AUTOCOMPLETION_FUNCTION(sar_workshop))
 {
 	// Command callback
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,14 +25,13 @@
     - [Buttons](#buttons)
   - [HUD](#hud)
     - [Elements](#elements)
-	- [Separate](#separate)
+    - [Separate](#separate)
   - [Game Support](#game-support)
     - [Versions](#versions)
     - [Unique Console Commands](#unique-console-commands)
   - [SDK](#sdk)
   - [Speedrun Timer](#speedrun-timer)
-    - [Rules](#rules)
-    - [Categories](#categories)
+    - [Rules & Categories](#rules--categories)
 
 ## Building
 
@@ -48,7 +47,7 @@
 - g++ 8.3.0
 - g++-8-multilib
 - Make 4.1
-- Configure paths in `makefile`
+- Configure paths in `config.mk`
 
 ## Pull Requests
 
@@ -61,13 +60,13 @@
 ### Quick Tutorial with git
 
 - Fork this repository on GitHub
-- git clone https://github.com/<your_account>/SourceAutoRecord
-- git remote add upstream https://github.com/p2sr/SourceAutoRecord
-- git fetch remotes/upstream/master
-- git checkout -b feature/something remotes/upstream/master
+- `git clone https://github.com/<your_account>/SourceAutoRecord`
+- `git remote add upstream https://github.com/p2sr/SourceAutoRecord`
+- `git fetch remotes/upstream/master`
+- `git checkout -b feature/something remotes/upstream/master`
 - *Change stuff and stage files*
-- git commit -m "New something"
-- git push origin feature/something
+- `git commit -m "New something"`
+- `git push origin feature/something`
 
 ### Merge existing branch (optionally)
 
@@ -137,7 +136,8 @@ public:
     virtual void Unload() = 0; // 1
     virtual void Pause() = 0; // 2
     virtual void UnPause() = 0; // 3
-    ...
+    // ...
+}
 ```
 
 It is recommended to use offsets instead of SDK classes as they can be different for every game since SAR's philosophy is to support as many games as possible. The number of offsets to get to an object should be kept as low as possible. Why use offsets and not signatures aka patterns? Because they are much faster during initialization and development. All offsets are declared in the `Offsets` namespace. If multiple variables have the same name rename them with a prefix. For example: `C_m_vecAbsOrigin` means client-side and `S_m_vecAbsOrigin` server-side.
@@ -156,8 +156,7 @@ DECL_DETOUR(CreateMove, float flInputSampleTime, CUserCmd* cmd)
 REDECL(Client::CreateMove);
 
 // int __cdecl Client::CreateMove_Hook(void* thisptr, float flInputSampleTime, CUserCmd* cmd)
-DETOUR(Client::CreateMove, float flInputSampleTime, CUserCmd* cmd)
-{
+DETOUR(Client::CreateMove, float flInputSampleTime, CUserCmd* cmd) {
     // Always call/return original function/value unless you know what you're doing
     return Client::CreateMove(thisptr, flInputSampleTime, cmd);
 }
@@ -194,16 +193,13 @@ extern MyFeature* myFeature;
 MyFeature* myFeature;
 
 MyFeature::MyFeature()
-    : state(0)
-{
+    : state(0) {
     this->hasLoaded = true;
 }
-void MyFeature::ChangeState(int newState)
-{
+void MyFeature::ChangeState(int newState) {
     this->state = newState;
 }
-int MyFeature::GetState()
-{
+int MyFeature::GetState() {
     return this->state;
 }
 
@@ -285,14 +281,11 @@ auto funcAddress = Memory::Absolute(MODULE("engine"), 0xdeadbeef);
 
 ```cpp
 // Boolean
-Variable sar_simple_mode("sar_simple_mode", "0",
-    "Useful help description.\n");
+Variable sar_simple_mode("sar_simple_mode", "0", "Useful help description.\n");
 // Float
-Variable sar_mode("sar_mode", "0", 0
-    "Useful help description.\n");
+Variable sar_mode("sar_mode", "0", 0, "Useful help description.\n");
 // String
-Variable sar_text("sar_text", "a string",
-    "Useful help description.\n", 0);
+Variable sar_text("sar_text", "a string", "Useful help description.\n", 0);
 
 // From the engine
 auto sv_cheats = Variable("sv_cheats");
@@ -309,8 +302,7 @@ Note: Keep a static version of a variable if it can be accessed more than once.
 Commands should always return a useful message if something went wrong.
 
 ```cpp
-CON_COMMAND(sar_hello, "Useful help description.\n")
-{
+CON_COMMAND(sar_hello, "Useful help description.\n") {
     if (args.ArgC() != 2) {
         return console->Print("Please enter a string!\n");
     }
@@ -326,20 +318,18 @@ CON_COMMAND(sar_hello, "Useful help description.\n")
 
 // Fastest way to declare a hidden autocompletion function
 // Last argument is type of std::vector<std::string>. It is required to wrap it with ()
-CON_COMMAND_COMPLETION(sar_force_fov, "Description.\n", ({ "0", "50", "60", "70", "80", "90", "100", "110", "120", "130", "140" }))
-{
-	// Command callback
+CON_COMMAND_COMPLETION(sar_force_fov, "Description.\n", ({ "0", "50", "60", "70", "80", "90", "100", "110", "120", "130", "140" })) {
+    // Command callback
 }
 
 // Use this macro in order to call some initialization logic
-DECL_COMMAND_COMPLETION(sar_workshop)
-{
-	// Init some stuff
+DECL_COMMAND_COMPLETION(sar_workshop) {
+    // Init some stuff
     if (workshop->maps.empty()) {
         workshop->Update();
     }
 
-	// Basic filtering logic
+    // Basic filtering logic
     for (auto& map : workshop->maps) {
         if (items.size() == COMMAND_COMPLETION_MAXITEMS) {
             break;
@@ -357,9 +347,8 @@ DECL_COMMAND_COMPLETION(sar_workshop)
     FINISH_COMMAND_COMPLETION();
 }
 
-CON_COMMAND_F_COMPLETION(sar_workshop, "Description.\n", 0, AUTOCOMPLETION_FUNCTION(sar_workshop))
-{
-	// Command callback
+CON_COMMAND_F_COMPLETION(sar_workshop, "Description.\n", FCVAR_NONE, AUTOCOMPLETION_FUNCTION(sar_workshop)) {
+    // Command callback
 }
 ```
 
@@ -367,60 +356,56 @@ CON_COMMAND_F_COMPLETION(sar_workshop, "Description.\n", 0, AUTOCOMPLETION_FUNCT
 
 #### Elements
 
-HUD elements can be declared with just a few lines of code. All elements are grouped together and start with `sar_hud_`. They also share the same settings starting with `sar_hud_default_`. The order of all elments can be customized by the user but the default order has to be declared separately.
+HUD elements can be declared with just a few lines of code. All elements are grouped together and start with `sar_hud_`. They also share the same settings starting with `sar_hud_default_`. The order of all elements can be customized by the user but the default order has to be declared separately.
 
 ```cpp
 #include "Features/Hud/Hud.hpp"
 
 // Called if: sar_hud_frame 1
-HUD_ELEMENT(frame, "0", "Default example.\n", HudType_InGame | HudType_Paused)
-{
+HUD_ELEMENT(frame, "0", "Default example.\n", HudType_InGame | HudType_Paused) {
     ctx->DrawElement("frame: %i", session->currentFrame);
 }
 
 // Called if: sar_hud_some_mode > 0
-HUD_ELEMENT_MODE(some_mode, "0", 0, 5, "Mode example.\n", HudType_InGame | HudType_Paused)
-{
-	if (mode == 4) {
-		ctx->DrawElement("mode: 4");
-	} else {
-		ctx->DrawElement("mode: 1-3 or 5");
-	}
+HUD_ELEMENT_MODE(some_mode, "0", 0, 5, "Mode example.\n", HudType_InGame | HudType_Paused) {
+    if (mode == 4) {
+        ctx->DrawElement("mode: 4");
+    } else {
+        ctx->DrawElement("mode: 1-3 or 5");
+    }
 }
 
 // Called if: sar_hud_some_text[0] != '\0' (not empty)
-HUD_ELEMENT_STRING(some_text, "", 0, 5, "Text example.\n", HudType_InGame | HudType_Paused)
-{
+HUD_ELEMENT_STRING(some_text, "", 0, 5, "Text example.\n", HudType_InGame | HudType_Paused) {
     ctx->DrawElement("mode: %s", text);
 }
 
 // Splitscreen support needs a 2 at the end of the macro
-HUD_ELEMENT2(splitscreen, "0", "Slot example.\n", HudType_InGame | HudType_Paused)
-{
-	// Do something with slot
-	auto slot = ctx->slot;
+HUD_ELEMENT2(splitscreen, "0", "Slot example.\n", HudType_InGame | HudType_Paused) {
+    // Do something with slot
+    auto slot = ctx->slot;
 }
 
 // Limit an element for a specific game
 HUD_ELEMENT3(game_version, "0", "Game specific example.\n",
-	HudType_InGame | HudType_Paused, // Where to draw
-	false,							 // no splitscreens
-	SourceGame_Portal)				 // Portal only
-{
+    HudType_InGame | HudType_Paused, // Where to draw
+    false,                           // no splitscreens
+    SourceGame_Portal) {             // Portal only
+
 }
 ```
 
 Last step is to add the element name to the ordered list. It is used for autocompletion and allows users to manually script their HUD order.
 
-```
+```cpp
 // Features/Hud/Hud.cpp
 std::vector<std::string> elementOrder = {
-	// ...
-	"frame",
-	"some_mode",
-	"some_text",
-	"splitscreen",
-	"game_version"
+    // ...
+    "frame",
+    "some_mode",
+    "some_text",
+    "splitscreen",
+    "game_version"
 };
 ```
 
@@ -460,33 +445,30 @@ extern Variable sar_my_hud_font_index;
 
 #include "Variable.hpp"
 
-Variable sar_my_hud("sar_sr_hud", "0", 0, "Draws my HUD.\n");
-Variable sar_my_hud_x("sar_sr_hud_x", "0", 0, "X offset of my HUD.\n");
-Variable sar_my_hud_y("sar_sr_hud_y", "100", 0, "Y offset of my HUD.\n");
-Variable sar_my_hud_font_color("sar_sr_hud_font_color", "255 255 255 255", "RGBA font color of my HUD.\n", 0);
-Variable sar_my_hud_font_index("sar_sr_hud_font_index", "70", 0, "Font index of my HUD.\n");
+Variable sar_my_hud("sar_my_hud", "0", 0, "Draws my HUD.\n");
+Variable sar_my_hud_x("sar_my_hud_x", "0", 0, "X offset of my HUD.\n");
+Variable sar_my_hud_y("sar_my_hud_y", "100", 0, "Y offset of my HUD.\n");
+Variable sar_my_hud_font_color("sar_my_hud_font_color", "255 255 255 255", "RGBA font color of my HUD.\n", 0);
+Variable sar_my_hud_font_index("sar_my_hud_font_index", "70", 0, "Font index of my HUD.\n");
 
 MyHud myHud;
 
 MyHud::MyHud()
-    : Hud(HudType_InGame,         // Only when session is running (no-pauses)
-		false,                    // Do not draw for splitscreen (default)
-		SourceGame_Portal2Engine) // Support specific game verison (default is for every game)
-{
+    : Hud(HudType_InGame,     // Only when session is running (no-pauses)
+        false,                // Do not draw for splitscreen (default)
+        SourceGame_Portal2) { // Support specific game verison (default is for every game)
 }
 
 // Implement a more complex drawing logic if needed
-bool MyHud::ShouldDraw()
-{
-	// Calling the base function will resolve the HUD type condition
+bool MyHud::ShouldDraw() {
+    // Calling the base function will resolve the HUD type condition
     return sar_my_hud.GetBool() && Hud::ShouldDraw();
 }
 
-// Will be called if ShoulDraw allows it
+// Will be called if ShouldDraw allows it
 // The slot value is the current splitscreen index which will always
 // be 0 if we do not want splitscreens or if the game does not support them
-void MyHud::Paint(int slot)
-{
+void MyHud::Paint(int slot) {
     auto xOffset = sar_my_hud_x.GetInt();
     auto yOffset = sar_my_hud_y.GetInt();
 
@@ -498,9 +480,8 @@ void MyHud::Paint(int slot)
 
 // Useful for commands that need the exact position
 // See Feature/Hud/InputHud.cpp
-bool MyHud::GetCurrentSize(int& xSize, int& ySize)
-{
-	// Calc size and return value if hud is active
+bool MyHud::GetCurrentSize(int& xSize, int& ySize) {
+    // Calc size and return value if hud is active
     return false;
 }
 ```
@@ -508,6 +489,7 @@ bool MyHud::GetCurrentSize(int& xSize, int& ySize)
 #### Buttons
 
 Portal 2 Engine only.
+
 ```cpp
 #define IN_AUTOSTRAFE (1 << 31) // Make sure to use a unique flag
 
@@ -549,35 +531,6 @@ A minimal Source Engine SDK can be found in `src/Utils` folder.
 
 ### Speedrun Timer
 
-#### Rules
+#### Rules & Categories
 
-```cpp
-#include "Features/Speedrun/TimerRule.hpp"
-
-SAR_RULE3(moon_shot,        // Name of the rule
-    "sp_a4_finale4",        // Name of the map
-    "moon_portal_detector", // Name of the entity
-    SearchMode::Names)      // Search in entity list by name
-{
-    // Access property
-    auto portalCount = reinterpret_cast<int*>((uintptr_t)entity + 1337);
-
-    if (*portalCount != 0) {
-        return TimerAction::End; // Timer ends on this tick
-    }
-
-    return TimerAction::DoNothing; // Continue running
-}
-```
-
-Note: Pointers of entities will be cached when the server has loaded. Make sure that the entity lives long enough to get any valid states. This also means that entities which get created at a later time cannot be accessed.
-
-#### Categories
-
-```cpp
-#include "Features/Speedrun/TimerCategory.hpp"
-
-SAR_CATEGORY(ApertureTag,                       // Name of game or mod
-    RTA,                                        // Name of category
-    _Rules({ &out_of_shower, &end_credits }));  // List of rules
-```
+See `src/Features/Speedrun/CategoriesPreset.cpp`.

--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -95,7 +95,7 @@ CON_COMMAND(sar_delete_alias_cmds, "sar_delete_alias_cmds - deletes all alias co
 }
 
 DECL_AUTO_COMMAND_COMPLETION(sar_fast_load_preset, ({"none", "sla", "normal", "full"}))
-CON_COMMAND_F_COMPLETION(sar_fast_load_preset, "sar_fast_load_preset <preset> - sets all loading fixes to preset values\n", FCVAR_DONTRECORD, sar_fast_load_preset_CompletionFunc) {
+CON_COMMAND_F_COMPLETION(sar_fast_load_preset, "sar_fast_load_preset <preset> - sets all loading fixes to preset values\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(sar_fast_load_preset)) {
 	if (args.ArgC() != 2) {
 		console->Print(sar_fast_load_preset.ThisPtr()->m_pszHelpString);
 		return;

--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -105,7 +105,7 @@ CON_COMMAND_F_COMPLETION(sar_fast_load_preset, "sar_fast_load_preset <preset> - 
 
 #define CMD(x) engine->ExecuteCommand(x)
 	if (!strcmp(preset, "none")) {
-		if (!Game::isSpeedrunMod()) {
+		if (!Game::IsSpeedrunMod()) {
 			CMD("ui_loadingscreen_transition_time 1.0");
 			CMD("ui_loadingscreen_fadein_time 1.0");
 			CMD("ui_loadingscreen_mintransition_time 0.5");
@@ -115,7 +115,7 @@ CON_COMMAND_F_COMPLETION(sar_fast_load_preset, "sar_fast_load_preset <preset> - 
 		CMD("sar_loads_uncap 0");
 		CMD("sar_loads_norender 0");
 	} else if (!strcmp(preset, "sla")) {
-		if (!Game::isSpeedrunMod()) {
+		if (!Game::IsSpeedrunMod()) {
 			CMD("ui_loadingscreen_transition_time 0.0");
 			CMD("ui_loadingscreen_fadein_time 0.0");
 			CMD("ui_loadingscreen_mintransition_time 0.0");
@@ -125,7 +125,7 @@ CON_COMMAND_F_COMPLETION(sar_fast_load_preset, "sar_fast_load_preset <preset> - 
 		CMD("sar_loads_uncap 0");
 		CMD("sar_loads_norender 0");
 	} else if (!strcmp(preset, "normal")) {
-		if (!Game::isSpeedrunMod()) {
+		if (!Game::IsSpeedrunMod()) {
 			CMD("ui_loadingscreen_transition_time 0.0");
 			CMD("ui_loadingscreen_fadein_time 0.0");
 			CMD("ui_loadingscreen_mintransition_time 0.0");
@@ -135,7 +135,7 @@ CON_COMMAND_F_COMPLETION(sar_fast_load_preset, "sar_fast_load_preset <preset> - 
 		CMD("sar_loads_uncap 1");
 		CMD("sar_loads_norender 0");
 	} else if (!strcmp(preset, "full")) {
-		if (!Game::isSpeedrunMod()) {
+		if (!Game::IsSpeedrunMod()) {
 			CMD("ui_loadingscreen_transition_time 0.0");
 			CMD("ui_loadingscreen_fadein_time 0.0");
 			CMD("ui_loadingscreen_mintransition_time 0.0");

--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -132,7 +132,7 @@ public:
 // clang-format on
 #define CON_COMMAND_COMPLETION(name, description, completion) \
 	DECL_AUTO_COMMAND_COMPLETION(name, completion)               \
-	CON_COMMAND_F_COMPLETION(name, description, 0, name##_CompletionFunc)
+	CON_COMMAND_F_COMPLETION(name, description, 0, AUTOCOMPLETION_FUNCTION(name))
 
 std::vector<std::string> ParsePartialArgs(const char *partial);
 int _FileCompletionFunc(std::string extension, std::string rootdir, int exp_args, const char *partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH]);

--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -407,7 +407,7 @@ static const char *gameName() {
 	case SourceGame_PortalStoriesMel: return "mel";
 	case SourceGame_ThinkingWithTimeMachine: return "twtm";
 	case SourceGame_PortalReloaded: return "reloaded";
-	case SourceGame_Portal2: return Game::isSpeedrunMod() ? "srm" : "portal2";
+	case SourceGame_Portal2: return Game::IsSpeedrunMod() ? "srm" : "portal2";
 	default: return "other";
 	}
 }

--- a/src/Features/Demo/GhostEntity.cpp
+++ b/src/Features/Demo/GhostEntity.cpp
@@ -545,7 +545,7 @@ DECL_COMMAND_COMPLETION(ghost_spec_pov) {
 	FINISH_COMMAND_COMPLETION();
 }
 
-CON_COMMAND_F_COMPLETION(ghost_spec_pov, "ghost_spec_pov <name|none> - spectate the specified ghost\n", 0, ghost_spec_pov_CompletionFunc) {
+CON_COMMAND_F_COMPLETION(ghost_spec_pov, "ghost_spec_pov <name|none> - spectate the specified ghost\n", 0, AUTOCOMPLETION_FUNCTION(ghost_spec_pov)) {
 	if (args.ArgC() != 2) {
 		return console->Print(ghost_spec_pov.ThisPtr()->m_pszHelpString);
 	}

--- a/src/Features/Hud/Crosshair.cpp
+++ b/src/Features/Hud/Crosshair.cpp
@@ -430,7 +430,7 @@ CON_COMMAND_F_COMPLETION(sar_quickhud_set_texture,
                          "sar_quickhud_set_texture <filepath> - enter the base name, it will search for <filepath>1.png, <filepath>2.png, <filepath>3.png and <filepath>4.png\n"
                          "ex: sar_quickhud_set_texture \"E:\\Steam\\steamapps\\common\\Portal 2\\portal2\\krzyhau\"\n",
                          0,
-                         sar_quickhud_set_texture_CompletionFunc) {
+                         AUTOCOMPLETION_FUNCTION(sar_quickhud_set_texture)) {
 	if (args.ArgC() < 2) {
 		return console->Print(sar_quickhud_set_texture.ThisPtr()->m_pszHelpString);
 	}

--- a/src/Features/Hud/Hud.cpp
+++ b/src/Features/Hud/Hud.cpp
@@ -306,7 +306,7 @@ void HudElement::IndexAll() {
 DECL_AUTO_COMMAND_COMPLETION(sar_hud_order_top, (elementOrder))
 DECL_AUTO_COMMAND_COMPLETION(sar_hud_order_bottom, (elementOrder))
 
-CON_COMMAND_F_COMPLETION(sar_hud_order_top, "sar_hud_order_top <name> - orders hud element to top\n", FCVAR_DONTRECORD, sar_hud_order_top_CompletionFunc) {
+CON_COMMAND_F_COMPLETION(sar_hud_order_top, "sar_hud_order_top <name> - orders hud element to top\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(sar_hud_order_top)) {
 	if (args.ArgC() != 2) {
 		return console->Print("Orders hud element to top: sar_hud_order_top <name>\n");
 	}
@@ -332,7 +332,7 @@ CON_COMMAND_F_COMPLETION(sar_hud_order_top, "sar_hud_order_top <name> - orders h
 
 	console->Print("Moved HUD element %s to top.\n", args[1]);
 }
-CON_COMMAND_F_COMPLETION(sar_hud_order_bottom, "sar_hud_order_bottom <name> - orders hud element to bottom\n", FCVAR_DONTRECORD, sar_hud_order_bottom_CompletionFunc) {
+CON_COMMAND_F_COMPLETION(sar_hud_order_bottom, "sar_hud_order_bottom <name> - orders hud element to bottom\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(sar_hud_order_bottom)) {
 	if (args.ArgC() != 2) {
 		return console->Print("Set!\n");
 	}

--- a/src/Features/Hud/Hud.cpp
+++ b/src/Features/Hud/Hud.cpp
@@ -573,9 +573,16 @@ CON_COMMAND_F(sar_hud_set_text_color, "sar_hud_set_text_color <id> [color] - set
 	}
 }
 
-CON_COMMAND_F(sar_hud_hide_text, "sar_hud_hide_text <id> - hides the nth text value in the HUD\n", FCVAR_DONTRECORD) {
+CON_COMMAND_F(sar_hud_hide_text, "sar_hud_hide_text <id|all> - hides the nth text value in the HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		console->Print(sar_hud_hide_text.ThisPtr()->m_pszHelpString);
+		return;
+	}
+
+	if (!strcmp(args[1], "all")) {
+		for (auto &t : sar_hud_text_vals) {
+			t.second.draw = false;
+		}
 		return;
 	}
 
@@ -588,9 +595,16 @@ CON_COMMAND_F(sar_hud_hide_text, "sar_hud_hide_text <id> - hides the nth text va
 	sar_hud_text_vals[idx].draw = false;
 }
 
-CON_COMMAND_F(sar_hud_show_text, "sar_hud_show_text <id> - shows the nth text value in the HUD\n", FCVAR_DONTRECORD) {
+CON_COMMAND_F(sar_hud_show_text, "sar_hud_show_text <id|all> - shows the nth text value in the HUD\n", FCVAR_DONTRECORD) {
 	if (args.ArgC() < 2) {
 		console->Print(sar_hud_show_text.ThisPtr()->m_pszHelpString);
+		return;
+	}
+
+	if (!strcmp(args[1], "all")) {
+		for (auto &t : sar_hud_text_vals) {
+			t.second.draw = true;
+		}
 		return;
 	}
 

--- a/src/Features/Hud/InputHud.cpp
+++ b/src/Features/Hud/InputHud.cpp
@@ -560,7 +560,7 @@ void InputHud::AddElement(std::string name, int type) {
 }
 
 DECL_AUTO_COMMAND_COMPLETION(sar_ihud_preset, ({"normal", "normal_mouse", "tas"}))
-CON_COMMAND_F_COMPLETION(sar_ihud_preset, "sar_ihud_preset <preset> - modifies input hud based on given preset\n", FCVAR_DONTRECORD, sar_ihud_preset_CompletionFunc) {
+CON_COMMAND_F_COMPLETION(sar_ihud_preset, "sar_ihud_preset <preset> - modifies input hud based on given preset\n", FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(sar_ihud_preset)) {
 	if (args.ArgC() != 2) {
 		console->Print(sar_ihud_preset.ThisPtr()->m_pszHelpString);
 		return;
@@ -595,7 +595,7 @@ DECL_COMMAND_COMPLETION(sar_ihud_modify) {
 CON_COMMAND_F_COMPLETION(sar_ihud_modify,
 	"sar_ihud_modify <element|all> [param=value]... - modifies parameters in given element.\n"
     "Params: enabled, text, pos, x, y, width, height, font, background, highlight, textcolor, texthighlight, image, highlightimage, minhold.\n",
-	FCVAR_DONTRECORD, sar_ihud_modify_CompletionFunc
+	FCVAR_DONTRECORD, AUTOCOMPLETION_FUNCTION(sar_ihud_modify)
 ) {
 	if (args.ArgC() < 3) {
 		console->Print(sar_ihud_modify.ThisPtr()->m_pszHelpString);

--- a/src/Features/Speedrun/SpeedrunTimer.cpp
+++ b/src/Features/Speedrun/SpeedrunTimer.cpp
@@ -201,7 +201,7 @@ ON_EVENT_P(SESSION_START, -1000) {
 	g_inDemoLoad = false;
 }
 ON_EVENT(SESSION_START) {
-	if (SpeedrunTimer::IsRunning() && sar_speedrun_skip_cutscenes.GetBool() && sar.game->GetVersion() == SourceGame_Portal2 && !Game::isSpeedrunMod()) {
+	if (SpeedrunTimer::IsRunning() && sar_speedrun_skip_cutscenes.GetBool() && sar.game->GetVersion() == SourceGame_Portal2 && !Game::IsSpeedrunMod()) {
 		if (g_speedrun.lastMap == "sp_a2_bts6") {
 			engine->ExecuteCommand("ent_fire @exit_teleport Teleport; ent_fire @transition_script RunScriptCode TransitionFromMap()", true);
 		} else if (g_speedrun.lastMap == "sp_a3_00") {
@@ -290,7 +290,7 @@ int SpeedrunTimer::GetSegmentTicks() {
 	ticks += g_speedrun.saved;
 	if (!g_speedrun.isPaused && !g_speedrun.inCoopPause && (!engine->demoplayer->IsPlaying() || engine->demoplayer->IsPlaybackFixReady())) {
 
-		if (sar_speedrun_skip_cutscenes.GetBool() && sar.game->GetVersion() == SourceGame_Portal2 && !Game::isSpeedrunMod()) {
+		if (sar_speedrun_skip_cutscenes.GetBool() && sar.game->GetVersion() == SourceGame_Portal2 && !Game::IsSpeedrunMod()) {
 			if (g_speedrun.lastMap == "sp_a2_bts6") return 3112;
 			else if (g_speedrun.lastMap == "sp_a3_00") return 4666;
 		}

--- a/src/Features/WorkshopList.cpp
+++ b/src/Features/WorkshopList.cpp
@@ -70,7 +70,7 @@ DECL_COMMAND_COMPLETION(sar_workshop) {
 
 // Commands
 
-CON_COMMAND_F_COMPLETION(sar_workshop, "sar_workshop <file> [ss/changelevel] - same as \"map\" command but lists workshop maps\n", 0, sar_workshop_CompletionFunc) {
+CON_COMMAND_F_COMPLETION(sar_workshop, "sar_workshop <file> [ss/changelevel] - same as \"map\" command but lists workshop maps\n", 0, AUTOCOMPLETION_FUNCTION(sar_workshop)) {
 	if (args.ArgC() < 2) {
 		return console->Print(sar_workshop.ThisPtr()->m_pszHelpString);
 	}

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -97,7 +97,7 @@ std::string Game::VersionToString(int version) {
 	return games;
 }
 
-bool Game::isSpeedrunMod() {
+bool Game::IsSpeedrunMod() {
 	static bool checked = false;
 	static bool srm = false;
 

--- a/src/Game.hpp
+++ b/src/Game.hpp
@@ -41,5 +41,5 @@ public:
 	static std::vector<std::string> mapNames;
 	static std::vector<AchievementData> achievements;
 
-	static bool isSpeedrunMod();
+	static bool IsSpeedrunMod();
 };


### PR DESCRIPTION
- `cvar:<cvar>` and `#<cvar>` parsing for `cond` (LHS and RHS of `a=b`). If a command or unknown variable is used, it is assumed to be empty.
- `%<string>` parsing for `cond` (LHS of `a=b`)
- `sar_hud_{show,hide}_text all` at the behest of RealCreative
- refactored references of `xxx_CompletionFunc` to the helpful macro `AUTOCOMPLETION_FUNCTION(xxx)`

The symbols `#` and `%` are negotiable.