### PR TITLE
feat: cutscene skip for Calibration

### DIFF
--- a/src/Features/Speedrun/CategoriesPreset.cpp
+++ b/src/Features/Speedrun/CategoriesPreset.cpp
@@ -228,8 +228,8 @@ void InitSpeedrunCategoriesTo(std::map<std::string, SpeedrunCategory> *cats, std
 		*defaultCat = "Singleplayer";
 		*cats = {
 			{"Singleplayer", {{"Container Ride Start", "Vault Start", "Vault Save Start", "Moon Shot"}}},
-			{"Coop", {{"Coop Start", "Coop Course 5 End"}}},
-			{"Coop AC", {{"Coop Start", "Coop Course 6 End"}}},
+			{"Coop", {{"Coop Start", "Coop Fall Start", "Coop Course 5 End"}}},
+			{"Coop AC", {{"Coop Start", "Coop Fall Start", "Coop Course 6 End"}}},
 		};
 		*rules = {
 			{
@@ -291,7 +291,20 @@ void InitSpeedrunCategoriesTo(std::map<std::string, SpeedrunCategory> *cats, std
 					"mp_coop_start",
 					EntityInputRule{
 						ENTRULE_TARGETNAME,
-						"teleport_start",
+						"playmovie_connect_intro",
+						"",
+						"__MovieFinished",
+						"",
+					}),
+			},
+			{
+				"Coop Fall Start",
+				SpeedrunRule(
+					RuleAction::START,
+					"mp_coop_start",
+					EntityInputRule{
+						ENTRULE_TARGETNAME,
+						"cam_gun_B",
 						"",
 						"Enable",
 						"",

--- a/src/Features/Speedrun/SpeedrunTimer.cpp
+++ b/src/Features/Speedrun/SpeedrunTimer.cpp
@@ -802,15 +802,15 @@ std::string SpeedrunTimer::SimpleFormat(float raw) {
 	return std::string(format);
 }
 
-float SpeedrunTimer::UnFormat(const std::string &formated_time) {
+float SpeedrunTimer::UnFormat(const std::string &formatted_time) {
 	int h, m;
 	float s, total = 0;
 
-	if (sscanf(formated_time.c_str(), "%d:%d:%f", &h, &m, &s) >= 3) {
+	if (sscanf(formatted_time.c_str(), "%d:%d:%f", &h, &m, &s) >= 3) {
 		total = h * 3600.0f + m * 60.0f + s;
-	} else if (sscanf(formated_time.c_str(), "%d:%f", &m, &s) >= 2) {
+	} else if (sscanf(formatted_time.c_str(), "%d:%f", &m, &s) >= 2) {
 		total = m * 60.0f + s;
-	} else if (sscanf(formated_time.c_str(), "%f", &s) >= 1) {
+	} else if (sscanf(formatted_time.c_str(), "%f", &s) >= 1) {
 		total = s;
 	}
 

--- a/src/Features/Speedrun/SpeedrunTimer.cpp
+++ b/src/Features/Speedrun/SpeedrunTimer.cpp
@@ -216,8 +216,17 @@ ON_EVENT(SESSION_START) {
 	if (engine->GetCurrentMapName() == "mp_coop_start" && !engine->IsOrange()) {
 		// This is ridiculous
 		sv_cheats.ThisPtr()->m_nValue = 1;
-		engine->ExecuteCommand("ent_fire teleport_start enable; ent_fire playmovie_connect_intro kill; ent_fire relay_start_glados_coop kill; ent_fire pclip_tube_block_3 kill; ent_fire pclip_tube_block_1 kill", true);
-		engine->ExecuteCommand("ent_fire @global_no_pinging_blue TurnOff; ent_fire @global_no_pinging_orange TurnOff; ent_fire pclip_tube_block_2 kill", true);
+		engine->ExecuteCommand("ent_fire teleport_start enable; ent_fire playmovie_connect_intro kill; ent_fire relay_start_glados_coop kill", true);
+		engine->ExecuteCommand("ent_fire pclip_tube_block_3 kill; ent_fire pclip_tube_block_1 kill; ent_fire pclip_tube_block_2 kill", true);
+		sv_cheats.SetValue(sv_cheats.GetString());
+	}
+}
+
+// Fix pings
+ON_EVENT(SESSION_START) {
+	if (engine->GetCurrentMapName() == "mp_coop_start" && !engine->IsOrange()) {
+		sv_cheats.ThisPtr()->m_nValue = 1;
+		engine->ExecuteCommand("ent_fire @global_no_pinging_blue TurnOff; ent_fire @global_no_pinging_orange TurnOff", true);
 		sv_cheats.SetValue(sv_cheats.GetString());
 	}
 }

--- a/src/Features/Speedrun/SpeedrunTimer.hpp
+++ b/src/Features/Speedrun/SpeedrunTimer.hpp
@@ -12,7 +12,7 @@
 namespace SpeedrunTimer {
 	std::string Format(float raw);
 	std::string SimpleFormat(float raw);
-	float UnFormat(const std::string &formated_time);
+	float UnFormat(const std::string &formatted_time);
 
 	void Init();
 	void SetIpt(float ipt);

--- a/src/Modules/Client.cpp
+++ b/src/Modules/Client.cpp
@@ -60,6 +60,7 @@ REDECL(Client::CInput_CreateMove);
 REDECL(Client::GetButtonBits);
 REDECL(Client::SteamControllerMove);
 REDECL(Client::playvideo_end_level_transition_callback);
+REDECL(Client::playvideo_exitcommand_nointerrupt_callback);
 REDECL(Client::OverrideView);
 REDECL(Client::ProcessMovement);
 REDECL(Client::DrawTranslucentRenderables);
@@ -405,6 +406,14 @@ DETOUR_COMMAND(Client::playvideo_end_level_transition) {
 	return Client::playvideo_end_level_transition_callback(args);
 }
 
+DETOUR_COMMAND(Client::playvideo_exitcommand_nointerrupt) {
+	// If Orange has skip_cutscenes but Blue doesn't
+	if (sar_speedrun_skip_cutscenes.GetBool() && !strcmp(args.m_pArgSBuffer, "playvideo_exitcommand_nointerrupt coop_intro end_movie playmovie_connect_intro")) {
+		return;
+	}
+	return Client::playvideo_exitcommand_nointerrupt_callback(args);
+}
+
 DETOUR(Client::OverrideView, CViewSetup *m_View) {
 	camera->OverrideView(m_View);
 	Stitcher::OverrideView(m_View);
@@ -557,6 +566,7 @@ bool Client::Init() {
 			}
 
 			Command::Hook("playvideo_end_level_transition", Client::playvideo_end_level_transition_callback_hook, Client::playvideo_end_level_transition_callback);
+			Command::Hook("playvideo_exitcommand_nointerrupt", Client::playvideo_exitcommand_nointerrupt_callback_hook, Client::playvideo_exitcommand_nointerrupt_callback);
 		}
 
 		auto HudProcessInput = this->g_ClientDLL->Original(Offsets::HudProcessInput, readJmp);
@@ -655,6 +665,7 @@ void Client::Shutdown() {
 	Interface::Delete(this->g_HudSaveStatus);
 	Interface::Delete(this->g_GameMovement);
 	Command::Unhook("playvideo_end_level_transition", Client::playvideo_end_level_transition_callback);
+	Command::Unhook("playvideo_exitcommand_nointerrupt", Client::playvideo_exitcommand_nointerrupt_callback);
 }
 
 Client *client;

--- a/src/Modules/Client.hpp
+++ b/src/Modules/Client.hpp
@@ -124,6 +124,8 @@ public:
 
 	DECL_DETOUR_COMMAND(playvideo_end_level_transition);
 
+	DECL_DETOUR_COMMAND(playvideo_exitcommand_nointerrupt);
+
 	bool Init() override;
 	void Shutdown() override;
 	const char *Name() override {


### PR DESCRIPTION
`sar_speedrun_skip_cutscenes 1` now works for Calibration!

If Blue has the cvar on, the video / taunting / pinging section is entirely skipped and an offset of 45.083 is applied when the timer starts (just before hitting the ground). Orange doesn't even need SAR for this to work! The offset and starting point is negotiable.

If Orange has the cvar on but Blue doesn't, they don't have to do `stopvideos` as the video will never play for them. As far as I can tell this is perfectly legitimate.

- Migrated regular coop start rule to a different input (on the same tick) so this would work
- Refactored extra `ent_fire` out of Tube Ride / Long Fall skips (they were never properly fired anyway because of pesky pesky breakset)
- Fixed occasional coop bug wherein the ability of the robots to ping was preserved through resets, leading to confusion. This fix is always enabled, but on request I can put this behind a cvar.