### PR TITLE
fix: `sar_hud_show_text` error message

### DIFF
--- a/src/Features/Hud/Hud.cpp
+++ b/src/Features/Hud/Hud.cpp
@@ -611,7 +611,7 @@ CON_COMMAND_F(sar_hud_show_text, "sar_hud_show_text <id|all> - shows the nth tex
 
 	long idx = parseIdx(args[1]);
 	if (idx == -1) {
-		console->Print(sar_hud_hide_text.ThisPtr()->m_pszHelpString);
+		console->Print(sar_hud_show_text.ThisPtr()->m_pszHelpString);
 		return;
 	}
 


### PR DESCRIPTION

### Describe the issue

When an invalid text index is passed to `sar_hud_show_text`, the help string for `sar_hud_hide_text` is printed.

### Steps to reproduce:

```
sar_hud_show_text a
```