### PR TITLE
feat: add easing types for setang tas tool

### DIFF
--- a/src/Features/Tas/TasTools/AngleToolsUtils.cpp
+++ b/src/Features/Tas/TasTools/AngleToolsUtils.cpp
@@ -1,0 +1,61 @@
+#include "AngleToolsUtils.hpp"
+
+namespace AngleToolsUtils {
+	float Ease(float t, EasingType easingType) {
+		if (t == 0.0f || t == 1.0f) return t;
+
+		switch (easingType) {
+		case Sine:
+			return (cosf(M_PI * t) - 1.0f) / -2.0f;
+		case Cubic:
+			return t < 0.5f ? 4.0f * t * t * t : 1.0f - powf(-2.0f * t + 2.0f, 3.0f) / 2.0f;
+		case Exponential:
+			return t < 0.5f ? powf(2.0f, 20.0f * t - 10.0f) / 2 : (2 - powf(2.0f, -20.0f * t + 10.0f)) / 2.0f;
+		default:
+			return t;
+		}
+	}
+
+	EasingType ParseEasingType(std::string typeStr) {
+		if (typeStr.length() == 0 || typeStr == "linear") {
+			return Linear;
+		} else if (typeStr == "sine" || typeStr == "sin") {
+			return Sine;
+		} else if (typeStr == "cubic") {
+			return Cubic;
+		} else if (typeStr == "exponential" || typeStr == "exp") {
+			return Exponential;
+		} else {
+			throw;
+		}
+	}
+
+	Vector GetInterpolatedViewAnalog(Vector currentAngles, Vector targetAngles, int easingTicks, int elapsedTicks, EasingType easingType) {
+		Vector requiredDelta = currentAngles - targetAngles;
+
+		while (requiredDelta.y < 0.0f) requiredDelta.y += 360.0f;
+		if (requiredDelta.y > 180.0f) requiredDelta.y -= 360.0f;
+
+		float pitchDelta, yawDelta;
+
+		if (easingType == Linear || elapsedTicks >= easingTicks - 1) {
+			int remaining = std::max(easingTicks - elapsedTicks, 1);
+
+			pitchDelta = requiredDelta.x / remaining;
+			yawDelta = requiredDelta.y / remaining;
+		} else {
+			float realFactorNow = elapsedTicks / (float)easingTicks;
+			float realFactorNext = (elapsedTicks + 1) / (float)easingTicks;
+			float easeFactorNow = Ease(realFactorNow, easingType);
+			float easeFactorNext = Ease(realFactorNext, easingType);
+
+			// how much of the remaining angle distance we should move
+			float partFactor = (easeFactorNext - easeFactorNow) / (1.0f - easeFactorNow);
+
+			pitchDelta = requiredDelta.x * partFactor;
+			yawDelta = requiredDelta.y * partFactor;
+		}
+
+		return Vector{yawDelta, pitchDelta};
+	}
+}

--- a/src/Features/Tas/TasTools/AngleToolsUtils.hpp
+++ b/src/Features/Tas/TasTools/AngleToolsUtils.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <Utils/Math.hpp>
+
+namespace AngleToolsUtils {
+	enum EasingType {
+		Linear,
+		Sine,
+		Cubic,
+		Exponential,
+	};
+
+	float Ease(float t, EasingType easingType);
+	EasingType ParseEasingType(std::string typeStr);
+	Vector GetInterpolatedViewAnalog(Vector currentAngles, Vector targetAngles, int easingTicks, int elapsedTicks, EasingType easingType);
+}

--- a/src/Features/Tas/TasTools/AutoAimTool.cpp
+++ b/src/Features/Tas/TasTools/AutoAimTool.cpp
@@ -5,6 +5,9 @@
 #include "Features/EntityList.hpp"
 #include "Features/Tas/TasParser.hpp"
 #include "StrafeTool.hpp"
+#include "Features/Tas/TasTools/AngleToolsUtils.hpp"
+
+using namespace AngleToolsUtils;
 
 AutoAimTool autoAimTool[2] = {{0}, {1}};
 
@@ -12,58 +15,69 @@ struct AutoAimParams : public TasToolParams {
 	AutoAimParams()
 		: TasToolParams(false) {}
 
-	AutoAimParams(Vector point, int ticks)
+	AutoAimParams(Vector point, int easingTicks, EasingType easingType)
 		: TasToolParams(true)
 		, entity(false)
 		, point(point)
-		, ticks(ticks)
-		, elapsed(0) {}
+		, easingTicks(easingTicks)
+		, easingType(easingType)
+		, elapsedTicks(0) {}
 
-	AutoAimParams(std::string selector, int ticks)
+	AutoAimParams(std::string selector, int easingTicks, EasingType easingType)
 		: TasToolParams(true)
 		, entity(true)
 		, ent_selector(selector)
-		, ticks(ticks)
-		, elapsed(0) {}
+		, easingTicks(easingTicks)
+		, easingType(easingType)
+		, elapsedTicks(0) {}
 
 	bool entity;
 	std::string ent_selector;
 	Vector point;
-	int ticks;
-	int elapsed;
+	int easingTicks;
+	EasingType easingType;
+	int elapsedTicks;
 };
 
 std::shared_ptr<TasToolParams> AutoAimTool::ParseParams(std::vector<std::string> args) {
-	if (args.size() != 1 && args.size() != 2 && args.size() != 3 && args.size() != 4)
+	bool usesEntitySelector = args.size() > 0 && args[0] == "ent";
+
+	if (args.size() < 1 || args.size() > (usesEntitySelector ? 4 : 5)) {
 		throw TasParserException(Utils::ssprintf("Wrong argument count for tool %s: %d", this->GetName(), args.size()));
-	
-	if (args.size() == 1)
-		if (args[0] == "off")
-			return std::make_shared<AutoAimParams>();
-		else 
-			throw TasParserException(Utils::ssprintf("Bad argument for tool %s: %s", this->GetName(), args[0].c_str()));
-
-	if ((args.size() == 2 || args.size() == 3) && args[0] == "ent") {
-		int ticks;
-
-		try {
-			ticks = args.size() == 3 ? std::stoi(args[2]) : 1;
-		} catch (...) {
-			throw TasParserException(Utils::ssprintf("Bad tick value for tool %s: %s", this->GetName(), args[2].c_str()));
-		}
-
-		return std::make_shared<AutoAimParams>(args[1], ticks);
 	}
 
-	if (args.size() == 2) {
+	if (args.size() == 1 && args[0] == "off") {
+		return std::make_shared<AutoAimParams>();
+	} 
+	else if (!usesEntitySelector && args.size() < 3) {
 		throw TasParserException(Utils::ssprintf("Bad argument for tool %s: %s", this->GetName(), args[0].c_str()));
 	}
 
-	if (args.size() == 3 || args.size() == 4) {
+	int ticks;
+	EasingType easingType;
+
+	// ticks
+	unsigned ticksPos = usesEntitySelector ? 2 : 3;
+	try {
+		ticks = args.size() >= ticksPos + 1 ? std::stoi(args[ticksPos]) : 1;
+	} catch (...) {
+		throw TasParserException(Utils::ssprintf("Bad tick value for tool %s: %s", this->GetName(), args[ticksPos].c_str()));
+	}
+
+	// easing type
+	unsigned typePos = usesEntitySelector ? 3 : 4;
+	try {
+		easingType = ParseEasingType(args.size() >= typePos + 1 ? args[typePos] : "linear");
+	} catch (...) {
+		throw TasParserException(Utils::ssprintf("Bad interpolation value for tool %s: %s", this->GetName(), args[typePos].c_str()));
+	}
+
+	if (usesEntitySelector) {
+		return std::make_shared<AutoAimParams>(args[1], ticks, easingType);
+	} else {
 		float x;
 		float y;
 		float z;
-		int ticks;
 
 		try {
 			x = std::stof(args[0]);
@@ -83,13 +97,7 @@ std::shared_ptr<TasToolParams> AutoAimTool::ParseParams(std::vector<std::string>
 			throw TasParserException(Utils::ssprintf("Bad z value for tool %s: %s", this->GetName(), args[2].c_str()));
 		}
 
-		try {
-			ticks = args.size() == 4 ? std::stoi(args[3]) : 1;
-		} catch (...) {
-			throw TasParserException(Utils::ssprintf("Bad tick value for tool %s: %s", this->GetName(), args[3].c_str()));
-		}
-
-		return std::make_shared<AutoAimParams>(Vector{x, y, z}, ticks);
+		return std::make_shared<AutoAimParams>(Vector{x, y, z}, ticks, easingType);
 	}
 
 	return nullptr;
@@ -102,12 +110,6 @@ void AutoAimTool::Reset() {
 void AutoAimTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 	auto params = std::static_pointer_cast<AutoAimParams>(this->params);
 	if (!params->enabled) return;
-
-	int remaining = 1; // If there are no lerp ticks left, pretend we're on the last tick, so that we jump all the way to the final angle
-	if (params->elapsed < params->ticks) {
-		remaining = params->ticks - params->elapsed;
-		++params->elapsed;
-	}
 
 	void *player = server->GetPlayer(playerInfo.slot + 1);
 	if (!player) return;
@@ -137,19 +139,21 @@ void AutoAimTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 	pitch *= 180.0f / M_PI;
 	yaw *= 180.0f / M_PI;
 
-	Vector requiredDelta = QAngleToVector(playerInfo.angles) - Vector{pitch, yaw};
-
-	while (requiredDelta.y < 0.0f) requiredDelta.y += 360.0f;
-	if (requiredDelta.y > 180.0f) requiredDelta.y -= 360.0f;
-
-	float pitchDelta = requiredDelta.x / remaining;
-	float yawDelta = requiredDelta.y / remaining;
+	bulk.viewAnalog = GetInterpolatedViewAnalog(
+		QAngleToVector(playerInfo.angles), 
+		Vector{pitch, yaw}, 
+		params->easingTicks, 
+		params->elapsedTicks, 
+		params->easingType
+	);
 
 	if (sar_tas_debug.GetBool()) {
 		console->Print("autoaim pitch:%.2f yaw:%.2f\n", pitch, yaw);
 	}
 
-	bulk.viewAnalog = Vector{yawDelta, pitchDelta};
+	if (params->elapsedTicks < params->easingTicks) {
+		++params->elapsedTicks;
+	}
 
 	//do not let autoaim affect current movement direction. this will allow autoaim to be more precise with its prediction
 	//float yawRaw = DEG2RAD(yawDelta);

--- a/src/Features/Tas/TasTools/SetAngleTool.hpp
+++ b/src/Features/Tas/TasTools/SetAngleTool.hpp
@@ -2,6 +2,7 @@
 #include "Features/Tas/TasPlayer.hpp"
 #include "Features/Tas/TasTool.hpp"
 
+
 class SetAngleTool : public TasTool {
 public:
 	SetAngleTool(int slot)

--- a/src/SourceAutoRecord.vcxproj
+++ b/src/SourceAutoRecord.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="Features\Hud\StrafeHud.cpp" />
     <ClCompile Include="Features\Routing\Ruler.cpp" />
     <ClCompile Include="Features\SeasonalASCII.cpp" />
+    <ClCompile Include="Features\Tas\TasTools\AngleToolsUtils.cpp" />
     <ClCompile Include="Features\WindowResizer.cpp" />
     <ClCompile Include="Games\ApertureTag.cpp" />
     <ClCompile Include="Games\Portal2.cpp" />
@@ -327,6 +328,7 @@
     <ClInclude Include="Features\Hud\StrafeHud.hpp" />
     <ClInclude Include="Features\Routing\Ruler.hpp" />
     <ClInclude Include="Features\SeasonalASCII.hpp" />
+    <ClInclude Include="Features\Tas\TasTools\AngleToolsUtils.hpp" />
     <ClInclude Include="Features\WindowResizer.hpp" />
     <ClInclude Include="Games\ApertureTag.hpp" />
     <ClInclude Include="Games\Portal2.hpp" />

--- a/src/SourceAutoRecord.vcxproj.filters
+++ b/src/SourceAutoRecord.vcxproj.filters
@@ -487,6 +487,9 @@
     <ClCompile Include="Features\Hud\StrafeHud.cpp">
       <Filter>SourceAutoRecord\Features\Hud</Filter>
     </ClCompile>
+    <ClCompile Include="Features\Tas\TasTools\AngleToolsUtils.cpp">
+      <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\minhook\buffer.h">
@@ -1259,6 +1262,9 @@
     </ClInclude>
     <ClInclude Include="Features\Hud\StrafeHud.hpp">
       <Filter>SourceAutoRecord\Features\Hud</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\Tas\TasTools\AngleToolsUtils.hpp">
+      <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Adds three additional easing types when interpolating to the desired angle using `setang` TAS automation tool: `sine`/`sin`, `cubic` and `exponential`/`exp`. A type should be given as a fourth parameter to setang. By default, it's still using linear interpolation, meaning this change should be backwards-compatible and doesn't require new script version.

All interpolation type went through very basic tests (me running a single setang for each type), but it would be nice for someone to make some further testing:
- verify if previously made TAS scripts still function properly
- attempt to interrupt `setang` with another `setang`
- check what happens if you pass through the portal while `setang` is in use and if the behaviour is consistent with previous version