### PR TITLE
feat: TAS player refactor and protocol improvements

### DIFF
--- a/docs/tas_proto.txt
+++ b/docs/tas_proto.txt
@@ -24,13 +24,17 @@ server (SAR) -> client (VSC extension):
 	[4] state = paused
 
 	[5] state = fast-forwarding
-		tick: u32
 
 	[6] update current tick
 		tick: u32
 
 	[7] update debug tick
 		tick: i32 // -1 if no debug tick
+
+	[10] processed script (sent when protocol script finished playing)
+		slot: u8
+		len: u32
+		script: [len]u8
 
 	[100] entity info response
 		state: u8 // if 0, the rest of the data is not sent
@@ -68,6 +72,16 @@ client (VSC extension) -> server (SAR):
 	
 	[7] advance tick (only valid when paused)
 	
+	[10] request playback (protocol script)
+		len1: u32
+		script1name: [len1]u8
+		len2: u32
+		script1: [len2]u8
+		len3: u32            // 0 if SP TAS
+		script2name: [len3]u8
+		len4: u32            // 0 if SP TAS
+		script2: [len4]u8
+
 	[100] request entity info
 		len: u32
 		entity_selector: [len]u8

--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -10,6 +10,7 @@
 #include "Features/ReloadedFix.hpp"
 #include "Features/Routing/EntityInspector.hpp"
 #include "Features/Speedrun/SpeedrunTimer.hpp"
+#include "Features/Tas/TasParser.hpp"
 #include "Features/Tas/TasTools/AutoJumpTool.hpp"
 #include "Features/Tas/TasTools/StrafeTool.hpp"
 #include "Features/Timer/Timer.hpp"
@@ -370,6 +371,7 @@ void Cheats::AutoStrafe(int slot, void *player, CUserCmd *cmd) {
 	float angle = Math::AngleNormalize(RAD2DEG(DEG2RAD(info.angles.y) + atan2(-cmd->sidemove, cmd->forwardmove)));
 
 	TasFramebulk fb;
+	tasPlayer->playbackInfo.slots[slot].header.version = MAX_SCRIPT_VERSION;
 	autoJumpTool[info.slot].SetParams(autoJumpTool[info.slot].ParseParams(std::vector<std::string>{sar_autojump.GetBool() && (cmd->buttons & IN_JUMP) ? "on" : "off"}));
 	autoStrafeTool[info.slot].SetParams(autoStrafeTool[info.slot].ParseParams(std::vector<std::string> {"vec", "max", std::to_string(angle) + "deg"}));
 	autoStrafeTool[info.slot].Apply(fb, info);

--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -315,10 +315,10 @@ void Cheats::Shutdown() {
 
 // FUN PATCHES :))))))
 
-void Cheats::PatchBhop(void *player, CUserCmd *cmd) {
+void Cheats::PatchBhop(int slot, void *player, CUserCmd *cmd) {
 	if (!server->AllowsMovementChanges() || !sar_patch_bhop.GetBool()) return;
 
-	TasPlayerInfo info = tasPlayer->GetPlayerInfo<true>(player, cmd);
+	TasPlayerInfo info = tasPlayer->GetPlayerInfo(slot, player, cmd);
 
 	float currVel = info.velocity.Length2D();
 	float predictVel = autoStrafeTool[info.slot].GetVelocityAfterMove(info, cmd->forwardmove, cmd->sidemove).Length2D();
@@ -356,7 +356,7 @@ ON_EVENT(PROCESS_MOVEMENT) {
 	}
 }
 
-void Cheats::AutoStrafe(void *player, CUserCmd *cmd) {
+void Cheats::AutoStrafe(int slot, void *player, CUserCmd *cmd) {
 	if (!server->AllowsMovementChanges() || !sar_autostrafe.GetBool()) return;
 
 	if (cmd->forwardmove == 0 && cmd->sidemove == 0) return;
@@ -365,7 +365,7 @@ void Cheats::AutoStrafe(void *player, CUserCmd *cmd) {
 
 	if (m_MoveType == MOVETYPE_NOCLIP) return;
 
-	TasPlayerInfo info = tasPlayer->GetPlayerInfo<true>(player, cmd);
+	TasPlayerInfo info = tasPlayer->GetPlayerInfo(slot, player, cmd);
 
 	float angle = Math::AngleNormalize(RAD2DEG(DEG2RAD(info.angles.y) + atan2(-cmd->sidemove, cmd->forwardmove)));
 

--- a/src/Cheats.hpp
+++ b/src/Cheats.hpp
@@ -7,8 +7,8 @@ public:
 	void Init();
 	void Shutdown();
 
-	static void PatchBhop(void *player, CUserCmd *cmd);
-	static void AutoStrafe(void *player, CUserCmd *cmd);
+	static void PatchBhop(int slot, void *player, CUserCmd *cmd);
+	static void AutoStrafe(int slot, void *player, CUserCmd *cmd);
 };
 
 extern Variable sar_autorecord;

--- a/src/Features/Camera.hpp
+++ b/src/Features/Camera.hpp
@@ -126,6 +126,7 @@ public:
 			origin + client->GetViewOffset(player) + client->GetPortalLocal(player).m_vEyeOffset;
 
 		eyeAng = serverside ? server->GetPlayerState(player).v_angle : client->GetPlayerState(player).v_angle;
+		eyeAng.y = Math::AngleNormalize(eyeAng.y);
 
 		TransformThroughPortal<serverside>(slot, eyePos, eyeAng);
 

--- a/src/Features/EntityList.cpp
+++ b/src/Features/EntityList.cpp
@@ -84,6 +84,16 @@ IHandleEntity *EntityList::LookupEntity(const CBaseHandle &handle) {
 CEntInfo *EntityList::QuerySelector(const char *selector) {
 	int slen = strlen(selector);
 	int entId = 0;
+
+	// try to verify if it's a slot number
+	int scanEnd;
+	if (sscanf(selector, "%d%n", &entId, &scanEnd) == 1 && scanEnd == slen) {
+		return entityList->GetEntityInfoByIndex(entId);
+	}
+
+	// if not, parse as name instead
+
+	// read list access operator
 	if (selector[slen - 1] == ']') {
 		int openBracket = slen - 2;
 		while (openBracket > 0 && selector[openBracket] != '[') {

--- a/src/Features/Hud/StrafeHud.cpp
+++ b/src/Features/Hud/StrafeHud.cpp
@@ -37,7 +37,7 @@ void StrafeHud::SetData(int slot, void *player, CUserCmd *cmd, bool serverside) 
 	data[slot].accelValues.clear();
 
 	// generate predicted accelerate values in a circle
-	auto playerInfo = serverside ? tasPlayer->GetPlayerInfo<true>(player, cmd) : tasPlayer->GetPlayerInfo<false>(player, cmd);
+	auto playerInfo = tasPlayer->GetPlayerInfo(slot, player, cmd, !serverside);
 	float oldVel = playerInfo.velocity.Length2D();
 
 	auto bestAng = autoStrafeTool->GetFastestStrafeAngle(playerInfo);

--- a/src/Features/Tas/TasController.cpp
+++ b/src/Features/Tas/TasController.cpp
@@ -134,7 +134,7 @@ void TasController::ControllerMove(int nSlot, float flFrametime, CUserCmd *cmd) 
 
 	// affect inputs only if the virtual controller is enabled
 	if (!enabled) return;
-	if (tasPlayer->coopControlSlot == nSlot) return;
+	if (tasPlayer->playbackInfo.coopControlSlot == nSlot) return;
 
 	//console->Print("TasController::ControllerMove (%d, ", cmd->tick_count);
 
@@ -203,7 +203,7 @@ void TasController::ControllerMove(int nSlot, float flFrametime, CUserCmd *cmd) 
 
 	// don't do this part if tools are enabled.
 	// tools processing will do it instead
-	if (!tasPlayer->IsUsingTools(nSlot)) {
+	if (!tasPlayer->IsUsingTools()) {
 		QAngle viewangles;
 		viewangles = engine->GetAngles(nSlot);
 

--- a/src/Features/Tas/TasController.cpp
+++ b/src/Features/Tas/TasController.cpp
@@ -146,9 +146,8 @@ void TasController::ControllerMove(int nSlot, float flFrametime, CUserCmd *cmd) 
 	cmd->upmove = 0;
 	cmd->buttons = 0;
 
-	//in terms of functionality, this whole stuff below is mostly a literal copy of SteamControllerMove.
-
-	//handle digital inputs
+	// Handle digital inputs. 
+	// It's a mess because it was copied from original SteamControllerMove.
 	for (int i = 0; i < TAS_CONTROLLER_INPUT_COUNT; i++) {
 		TasControllerButton *button = &buttons[i];
 		if (button->active && button->command[0] == '+') {
@@ -174,13 +173,11 @@ void TasController::ControllerMove(int nSlot, float flFrametime, CUserCmd *cmd) 
 		}
 	}
 
-	// handle all additional commands from the command queue (not in the original, but um why not?)
+	// Handle all additional commands from the command queue
 	if (commandQueue.size() > 0) {
 		tasPlayer->inControllerCommands = true;
 		for (std::string cmd : commandQueue) {
-			char cmdbuf[128];
-			snprintf(cmdbuf, sizeof(cmdbuf), "%s", cmd.c_str());
-			engine->ExecuteCommand(cmdbuf, true);
+			engine->ExecuteCommand(cmd.c_str(), true);
 		}
 		commandQueue.clear();
 		tasPlayer->inControllerCommands = false;

--- a/src/Features/Tas/TasParser.cpp
+++ b/src/Features/Tas/TasParser.cpp
@@ -194,7 +194,6 @@ static std::vector<Line> tokenize(std::istream &file) {
 	return lines;
 }
 
-#define MAX_SCRIPT_VERSION 7
 #define _STR1(x) #x
 #define _STR(x) _STR1(x)
 

--- a/src/Features/Tas/TasParser.hpp
+++ b/src/Features/Tas/TasParser.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "TasScript.hpp"
 
+#define MAX_SCRIPT_VERSION 7
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/Features/Tas/TasParser.hpp
+++ b/src/Features/Tas/TasParser.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "TasPlayer.hpp"
+#include "TasScript.hpp"
 
 #include <iostream>
 #include <string>
@@ -17,10 +17,10 @@ struct TasParserException : public std::exception {
 };
 
 namespace TasParser {
-	std::vector<TasFramebulk> ParseFile(int slot, std::string filePath);
-	std::vector<TasFramebulk> ParseScript(int slot, std::string scriptName, std::string scriptString);
-	void SaveFramebulksToFile(std::string name, TasStartInfo startInfo, bool wasStartNext, int version, std::vector<TasFramebulk> framebulks);
-	std::string SaveFramebulksToString(TasStartInfo startInfo, bool wasStartNext, int version, std::vector<TasFramebulk> framebulks);
+	TasScript ParseFile(std::string filePath);
+	TasScript ParseScript(std::string scriptName, std::string scriptString);
+	void SaveRawScriptToFile(TasScript script);
+	std::string SaveRawScriptToString(TasScript script);
 	int toInt(std::string &str);
 	float toFloat(std::string str);
 };

--- a/src/Features/Tas/TasParser.hpp
+++ b/src/Features/Tas/TasParser.hpp
@@ -18,7 +18,9 @@ struct TasParserException : public std::exception {
 
 namespace TasParser {
 	std::vector<TasFramebulk> ParseFile(int slot, std::string filePath);
+	std::vector<TasFramebulk> ParseScript(int slot, std::string scriptName, std::string scriptString);
 	void SaveFramebulksToFile(std::string name, TasStartInfo startInfo, bool wasStartNext, int version, std::vector<TasFramebulk> framebulks);
+	std::string SaveFramebulksToString(TasStartInfo startInfo, bool wasStartNext, int version, std::vector<TasFramebulk> framebulks);
 	int toInt(std::string &str);
 	float toFloat(std::string str);
 };

--- a/src/Features/Tas/TasPlayer.cpp
+++ b/src/Features/Tas/TasPlayer.cpp
@@ -227,10 +227,6 @@ void TasPlayer::Start() {
 		console->Print("Length: %d ticks\n", lastTick + 1);
 	}
 
-	if (playbackInfo.GetMainHeader().startInfo.type == ChangeLevelCM) {
-		sv_bonus_challenge.SetValue(1);
-	}
-
 	ready = true;
 	currentTick = 0;
 	startTick = -1;

--- a/src/Features/Tas/TasPlayer.hpp
+++ b/src/Features/Tas/TasPlayer.hpp
@@ -67,6 +67,7 @@ private:
 	int startTick = 0;    // used to store the absolute tick in which player started playing the script
 	int currentTick = 0;  // tick position of script player, relative to its starting point.
 	int lastTick = 0;     // last tick of script, relative to its starting point
+	bool scriptLoadedFromFile = false;
 
 	int wasEnginePaused; // Used to check if we need to revert incrementing a tick
 
@@ -94,7 +95,8 @@ public:
 			&& (sar_tas_tools_force.GetBool() || this->tasFileName[slot].find("_raw") == std::string::npos);
 	}
 
-	void PlayFile(std::string slot0, std::string slot1);
+	void PlayFile(std::string slot0scriptPath, std::string slot1scriptPath);
+	void PlayScript(std::string slot0name, std::string slot0script, std::string slot1name, std::string slot1script);
 	void PlaySingleCoop(std::string file, int slot);
 
 	void Activate();

--- a/src/Features/Tas/TasScript.cpp
+++ b/src/Features/Tas/TasScript.cpp
@@ -1,0 +1,23 @@
+#include "TasScript.hpp"
+
+std::string TasFramebulk::ToString() {
+	std::string output = "[" + std::to_string(tick) + "] mov: (" + std::to_string(moveAnalog.x) + " " + std::to_string(moveAnalog.y) + "), ang:" + std::to_string(viewAnalog.x) + " " + std::to_string(viewAnalog.y) + "), btns:";
+	for (int i = 0; i < TAS_CONTROLLER_INPUT_COUNT; i++) {
+		output += (buttonStates[i]) ? "1" : "0";
+	}
+	output += ", cmds: ";
+	for (std::string command : commands) {
+		output += command + ";";
+	}
+	output += ", tools:";
+	for (TasToolCommand toolCmd : toolCmds) {
+		output += " {" + std::string(toolCmd.tool->GetName()) + "}";
+	}
+	return output;
+}
+
+void TasScript::ClearGeneratedContent() {
+	this->processedFramebulks.clear();
+	this->userCmdDebugs.clear();
+	this->playerInfoDebugs.clear();
+}

--- a/src/Features/Tas/TasScript.hpp
+++ b/src/Features/Tas/TasScript.hpp
@@ -1,0 +1,54 @@
+#pragma once
+#include <Features/Tas/TasController.hpp>
+#include <Features/Tas/TasTool.hpp>
+
+
+enum TasScriptStartType {
+	ChangeLevel,
+	ChangeLevelCM,
+	LoadQuicksave,
+	StartImmediately,
+};
+
+struct TasScriptStartInfo {
+	bool isNext;
+	TasScriptStartType type;
+	std::string param;
+};
+
+struct TasScriptHeader {
+	int version;
+	TasScriptStartInfo startInfo;
+	std::string rngManipFile;
+};
+
+struct TasFramebulk {
+	int tick = 0;
+	Vector moveAnalog = {0, 0};
+	Vector viewAnalog = {0, 0};
+	bool buttonStates[TAS_CONTROLLER_INPUT_COUNT] = {0};
+	std::vector<std::string> commands;
+	std::vector<TasToolCommand> toolCmds;
+
+	std::string ToString();
+};
+
+
+struct TasScript {
+	std::string name;
+	TasScriptHeader header;
+	std::vector<TasFramebulk> framebulks;
+	
+	bool loadedFromFile;
+	bool forceRawPlayback = false;
+	std::vector<TasFramebulk> processedFramebulks;
+	std::vector<std::string> userCmdDebugs;
+	std::vector<std::string> playerInfoDebugs;
+	
+	inline bool IsRaw() const {
+		return forceRawPlayback || (name.length() > 0 && name.find("_raw") != std::string::npos);
+	}
+	inline bool IsActive() const { return framebulks.size() > 0; }
+
+	void ClearGeneratedContent();
+};

--- a/src/Features/Tas/TasServer.cpp
+++ b/src/Features/Tas/TasServer.cpp
@@ -311,13 +311,13 @@ static bool processCommands(ClientData &cl) {
 			break;
 
 		case 100: // request entity info
-			if (extra < 8) return true;
+			if (extra < 4) return true;
 			{
 				std::deque<uint8_t> copy = cl.cmdbuf;
 				copy.pop_front();
 
 				uint32_t len = popRaw32(copy);
-				if (extra < 8 + len) return true;
+				if (extra < 4 + len) return true;
 
 				std::string entSelector;
 				for (size_t i = 0; i < len; ++i) {

--- a/src/Features/Tas/TasServer.cpp
+++ b/src/Features/Tas/TasServer.cpp
@@ -535,18 +535,18 @@ void TasServer::SetStatus(TasStatus s) {
 	g_status_mutex.unlock();
 }
 
-void TasServer::SendProcessedScript(std::string slot0scriptString, std::string slot1scriptString) {
+void TasServer::SendProcessedScript(uint8_t slot, std::string scriptString) {
 	std::vector<uint8_t> buf;
 
 	// processed script reply (10)
 	buf.push_back(10);
-	encodeRaw32(buf, (uint32_t)slot0scriptString.size());
-	for (char c : slot0scriptString) {
-		buf.push_back(c);
-	}
 
-	encodeRaw32(buf, (uint32_t)slot1scriptString.size());
-	for (char c : slot1scriptString) {
+	// slot
+	buf.push_back(slot);
+
+	// script
+	encodeRaw32(buf, (uint32_t)scriptString.size());
+	for (char c : scriptString) {
 		buf.push_back(c);
 	}
 

--- a/src/Features/Tas/TasServer.hpp
+++ b/src/Features/Tas/TasServer.hpp
@@ -18,4 +18,5 @@ struct TasStatus {
 
 namespace TasServer {
 	void SetStatus(TasStatus s);
+	void SendProcessedScript(std::string slot0scriptString, std::string slot1scriptString);
 };

--- a/src/Features/Tas/TasServer.hpp
+++ b/src/Features/Tas/TasServer.hpp
@@ -18,5 +18,5 @@ struct TasStatus {
 
 namespace TasServer {
 	void SetStatus(TasStatus s);
-	void SendProcessedScript(std::string slot0scriptString, std::string slot1scriptString);
+	void SendProcessedScript(uint8_t slot, std::string scriptString);
 };

--- a/src/Features/Tas/TasTool.cpp
+++ b/src/Features/Tas/TasTool.cpp
@@ -8,6 +8,13 @@ std::list<TasTool *> &TasTool::GetList(int slot) {
 	return list[slot];
 }
 
+TasTool *TasTool::GetInstanceByName(int slot, std::string name) {
+	for (TasTool *tool : TasTool::GetList(slot)) {
+		if (tool->GetName() == name) return tool;
+	}
+	return nullptr;
+}
+
 std::vector<std::string> TasTool::priorityList = {
 	"check",
 	"setang",
@@ -42,7 +49,7 @@ void TasTool::SetParams(std::shared_ptr<TasToolParams> params) {
 	this->updated = true;
 
 	// legacy behaviour for version 2 or older
-	if (tasPlayer->scriptVersion <= 2) {
+	if (tasPlayer->GetScriptVersion(slot) <= 2) {
 		// the tool has been updated. prioritize it by moving it to the end of the global list
 		// mlugg please don't kill me
 		GetList(slot).splice(GetList(slot).end(), GetList(slot), std::find(GetList(slot).begin(), GetList(slot).end(), this));

--- a/src/Features/Tas/TasTool.cpp
+++ b/src/Features/Tas/TasTool.cpp
@@ -45,7 +45,7 @@ const char *TasTool::GetName() {
 }
 
 void TasTool::SetParams(std::shared_ptr<TasToolParams> params) {
-	this->params = params;
+	this->paramsPtr = params;
 	this->updated = true;
 
 	// legacy behaviour for version 2 or older
@@ -56,10 +56,7 @@ void TasTool::SetParams(std::shared_ptr<TasToolParams> params) {
 	}
 }
 
-void TasTool::Reset() {
-	params = std::make_shared<TasToolParams>();
-}
 
-std::shared_ptr<TasToolParams> TasTool::GetCurrentParams() {
-	return params;
+void TasTool::Reset() {
+	paramsPtr = std::make_shared<TasToolParams>();
 }

--- a/src/Features/Tas/TasTool.hpp
+++ b/src/Features/Tas/TasTool.hpp
@@ -25,14 +25,12 @@ struct TasToolParams {
 struct TasFramebulk;
 struct TasPlayerInfo;
 
-
 class TasTool {
 protected:
 	const char *name;
-	std::shared_ptr<TasToolParams> params = nullptr;
+	std::shared_ptr<TasToolParams> paramsPtr = nullptr;
 	bool updated = false;
 	int slot;
-
 public:
 	TasTool(const char *name, int slot);
 	~TasTool();
@@ -41,15 +39,33 @@ public:
 
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>) = 0;
 	virtual void Apply(TasFramebulk &fb, const TasPlayerInfo &pInfo) = 0;
-	virtual void Reset();
-
-	void SetParams(std::shared_ptr<TasToolParams> params);
-	std::shared_ptr<TasToolParams> GetCurrentParams();
-
+	virtual void Reset() = 0;
+	virtual void SetParams(std::shared_ptr<TasToolParams> params);
 public:
 	static std::list<TasTool *> &GetList(int slot);
 	static TasTool *GetInstanceByName(int slot, std::string name);
 	static std::vector<std::string> priorityList;
+};
+
+
+template <typename Params>
+class TasToolWithParams : public TasTool {
+protected:
+	Params params;
+public:
+	TasToolWithParams(const char *name, int slot)
+		: TasTool(name, slot){};
+
+	virtual void Reset() {
+		this->paramsPtr = std::make_shared<Params>();
+		this->params = *std::static_pointer_cast<Params>(this->paramsPtr);
+	}
+	virtual void SetParams(std::shared_ptr<TasToolParams> params) {
+		TasTool::SetParams(params);
+		this->params = *std::static_pointer_cast<Params>(params);
+	}
+
+	inline Params GetCurrentParams() const { return params; }
 };
 
 

--- a/src/Features/Tas/TasTool.hpp
+++ b/src/Features/Tas/TasTool.hpp
@@ -1,17 +1,19 @@
 #pragma once
 
-#include "TasPlayer.hpp"
 #include <list>
+#include <memory>
+#include <vector>
+#include <string>
 
 // A bunch of stuff accidentally used sin/cos directly, which led to
 // inconsistent scripts between Windows and Linux since Windows has
 // overloads for some functions. These helper macros dispatch to
 // sinf/cosf on newer script versions for platform consistency
-#define absOld(x) ((tasPlayer->scriptVersion >= 3) ? fabsf(x) : abs(x)) // we noticed this one sooner lol
-#define sinOld(x) ((tasPlayer->scriptVersion >= 4) ? sinf(x) : sin(x))
-#define cosOld(x) ((tasPlayer->scriptVersion >= 4) ? cosf(x) : cos(x))
-#define atan2Old(x, y) ((tasPlayer->scriptVersion >= 4) ? atan2f(x, y) : atan2(x, y))
-#define powOld(x, y) ((tasPlayer->scriptVersion >= 4) ? powf(x, y) : pow(x, y))
+#define absOld(x) ((tasPlayer->GetScriptVersion(slot) >= 3) ? fabsf(x) : abs(x))  // we noticed this one sooner lol
+#define sinOld(x) ((tasPlayer->GetScriptVersion(slot) >= 4) ? sinf(x) : sin(x))
+#define cosOld(x) ((tasPlayer->GetScriptVersion(slot) >= 4) ? cosf(x) : cos(x))
+#define atan2Old(x, y) ((tasPlayer->GetScriptVersion(slot) >= 4) ? atan2f(x, y) : atan2(x, y))
+#define powOld(x, y) ((tasPlayer->GetScriptVersion(slot) >= 4) ? powf(x, y) : pow(x, y))
 
 struct TasToolParams {
 	bool enabled = false;
@@ -46,6 +48,7 @@ public:
 
 public:
 	static std::list<TasTool *> &GetList(int slot);
+	static TasTool *GetInstanceByName(int slot, std::string name);
 	static std::vector<std::string> priorityList;
 };
 

--- a/src/Features/Tas/TasTools/AbsoluteMoveTool.cpp
+++ b/src/Features/Tas/TasTools/AbsoluteMoveTool.cpp
@@ -10,9 +10,7 @@ AbsoluteMoveTool tasAbsoluteMoveTool[2] = {
 };
 
 void AbsoluteMoveTool::Apply(TasFramebulk &fb, const TasPlayerInfo &playerInfo) {
-	auto ttParams = std::static_pointer_cast<AbsoluteMoveToolParams>(params);
-
-	if (!ttParams->enabled)
+	if (!params.enabled)
 		return;
 
 	auto angles = playerInfo.angles;
@@ -26,14 +24,14 @@ void AbsoluteMoveTool::Apply(TasFramebulk &fb, const TasPlayerInfo &playerInfo) 
 		forward_coef = 1.0f;
 	}
 
-	float desired = ttParams->direction;
+	float desired = params.direction;
 	float rad = DEG2RAD(desired - angles.y);
 
 	float x = -sinf(rad);
 	float y = cosf(rad) / forward_coef;
 
-	x *= ttParams->strength;
-	y *= ttParams->strength;
+	x *= params.strength;
+	y *= params.strength;
 
 	if (y > 1.0f) {
 		// We can't actually move this fast. Scale the movement down so 'y'
@@ -74,8 +72,4 @@ std::shared_ptr<TasToolParams> AbsoluteMoveTool::ParseParams(std::vector<std::st
 	}
 
 	return std::make_shared<AbsoluteMoveToolParams>(angle, strength);
-}
-
-void AbsoluteMoveTool::Reset() {
-	params = std::make_shared<AbsoluteMoveToolParams>();
 }

--- a/src/Features/Tas/TasTools/AbsoluteMoveTool.cpp
+++ b/src/Features/Tas/TasTools/AbsoluteMoveTool.cpp
@@ -9,18 +9,18 @@ AbsoluteMoveTool tasAbsoluteMoveTool[2] = {
 	{ "absmov", 1 },
 };
 
-void AbsoluteMoveTool::Apply(TasFramebulk &fb, const TasPlayerInfo &pInfo) {
+void AbsoluteMoveTool::Apply(TasFramebulk &fb, const TasPlayerInfo &playerInfo) {
 	auto ttParams = std::static_pointer_cast<AbsoluteMoveToolParams>(params);
 
 	if (!ttParams->enabled)
 		return;
 
-	auto angles = pInfo.angles;
+	auto angles = playerInfo.angles;
 	angles.y -= fb.viewAnalog.x;
 	angles.x -= fb.viewAnalog.y;
 
 	float forward_coef;
-	if (fabsf(angles.x) >= 30.0f && !pInfo.grounded) {
+	if (fabsf(angles.x) >= 30.0f && !playerInfo.grounded) {
 		forward_coef = cosOld(DEG2RAD(angles.x));
 	} else {
 		forward_coef = 1.0f;

--- a/src/Features/Tas/TasTools/AbsoluteMoveTool.hpp
+++ b/src/Features/Tas/TasTools/AbsoluteMoveTool.hpp
@@ -16,13 +16,14 @@ struct AbsoluteMoveToolParams : public TasToolParams {
 	}
 };
 
-class AbsoluteMoveTool : public TasTool {
+class AbsoluteMoveTool : public TasToolWithParams<AbsoluteMoveToolParams> {
+private:
+	AbsoluteMoveToolParams amParams;
 public:
 	AbsoluteMoveTool(const char *name, int slot)
-		: TasTool(name, slot){};
+		: TasToolWithParams(name, slot){};
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &fb, const TasPlayerInfo &pInfo);
-	virtual void Reset();
 };
 
 extern AbsoluteMoveTool tasAbsoluteMoveTool[2];

--- a/src/Features/Tas/TasTools/AngleToolsUtils.cpp
+++ b/src/Features/Tas/TasTools/AngleToolsUtils.cpp
@@ -26,7 +26,7 @@ namespace AngleToolsUtils {
 		} else if (typeStr == "exponential" || typeStr == "exp") {
 			return Exponential;
 		} else {
-			throw;
+			throw 0;
 		}
 	}
 

--- a/src/Features/Tas/TasTools/AutoAimTool.cpp
+++ b/src/Features/Tas/TasTools/AutoAimTool.cpp
@@ -20,23 +20,20 @@ struct AutoAimParams : public TasToolParams {
 		, entity(false)
 		, point(point)
 		, easingTicks(easingTicks)
-		, easingType(easingType)
-		, elapsedTicks(0) {}
+		, easingType(easingType) {}
 
 	AutoAimParams(std::string selector, int easingTicks, EasingType easingType)
 		: TasToolParams(true)
 		, entity(true)
 		, ent_selector(selector)
 		, easingTicks(easingTicks)
-		, easingType(easingType)
-		, elapsedTicks(0) {}
+		, easingType(easingType) {}
 
 	bool entity;
 	std::string ent_selector;
 	Vector point;
 	int easingTicks;
 	EasingType easingType;
-	int elapsedTicks;
 };
 
 std::shared_ptr<TasToolParams> AutoAimTool::ParseParams(std::vector<std::string> args) {
@@ -111,6 +108,11 @@ void AutoAimTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 	auto params = std::static_pointer_cast<AutoAimParams>(this->params);
 	if (!params->enabled) return;
 
+	if (this->updated) {
+		elapsedTicks = 0;
+		this->updated = false;
+	}
+
 	void *player = server->GetPlayer(playerInfo.slot + 1);
 	if (!player) return;
 
@@ -143,7 +145,7 @@ void AutoAimTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 		QAngleToVector(playerInfo.angles), 
 		Vector{pitch, yaw}, 
 		params->easingTicks, 
-		params->elapsedTicks, 
+		elapsedTicks, 
 		params->easingType
 	);
 
@@ -151,8 +153,8 @@ void AutoAimTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 		console->Print("autoaim pitch:%.2f yaw:%.2f\n", pitch, yaw);
 	}
 
-	if (params->elapsedTicks < params->easingTicks) {
-		++params->elapsedTicks;
+	if (elapsedTicks < params->easingTicks) {
+		++elapsedTicks;
 	}
 
 	//do not let autoaim affect current movement direction. this will allow autoaim to be more precise with its prediction

--- a/src/Features/Tas/TasTools/AutoAimTool.cpp
+++ b/src/Features/Tas/TasTools/AutoAimTool.cpp
@@ -5,36 +5,8 @@
 #include "Features/EntityList.hpp"
 #include "Features/Tas/TasParser.hpp"
 #include "StrafeTool.hpp"
-#include "Features/Tas/TasTools/AngleToolsUtils.hpp"
-
-using namespace AngleToolsUtils;
 
 AutoAimTool autoAimTool[2] = {{0}, {1}};
-
-struct AutoAimParams : public TasToolParams {
-	AutoAimParams()
-		: TasToolParams(false) {}
-
-	AutoAimParams(Vector point, int easingTicks, EasingType easingType)
-		: TasToolParams(true)
-		, entity(false)
-		, point(point)
-		, easingTicks(easingTicks)
-		, easingType(easingType) {}
-
-	AutoAimParams(std::string selector, int easingTicks, EasingType easingType)
-		: TasToolParams(true)
-		, entity(true)
-		, ent_selector(selector)
-		, easingTicks(easingTicks)
-		, easingType(easingType) {}
-
-	bool entity;
-	std::string ent_selector;
-	Vector point;
-	int easingTicks;
-	EasingType easingType;
-};
 
 std::shared_ptr<TasToolParams> AutoAimTool::ParseParams(std::vector<std::string> args) {
 	bool usesEntitySelector = args.size() > 0 && args[0] == "ent";
@@ -51,7 +23,7 @@ std::shared_ptr<TasToolParams> AutoAimTool::ParseParams(std::vector<std::string>
 	}
 
 	int ticks;
-	EasingType easingType;
+	AngleToolsUtils::EasingType easingType;
 
 	// ticks
 	unsigned ticksPos = usesEntitySelector ? 2 : 3;
@@ -64,7 +36,7 @@ std::shared_ptr<TasToolParams> AutoAimTool::ParseParams(std::vector<std::string>
 	// easing type
 	unsigned typePos = usesEntitySelector ? 3 : 4;
 	try {
-		easingType = ParseEasingType(args.size() >= typePos + 1 ? args[typePos] : "linear");
+		easingType = AngleToolsUtils::ParseEasingType(args.size() >= typePos + 1 ? args[typePos] : "linear");
 	} catch (...) {
 		throw TasParserException(Utils::ssprintf("Bad interpolation value for tool %s: %s", this->GetName(), args[typePos].c_str()));
 	}
@@ -100,13 +72,8 @@ std::shared_ptr<TasToolParams> AutoAimTool::ParseParams(std::vector<std::string>
 	return nullptr;
 }
 
-void AutoAimTool::Reset() {
-	this->params = std::make_shared<AutoAimParams>();
-}
-
 void AutoAimTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
-	auto params = std::static_pointer_cast<AutoAimParams>(this->params);
-	if (!params->enabled) return;
+	if (!params.enabled) return;
 
 	if (this->updated) {
 		elapsedTicks = 0;
@@ -124,13 +91,13 @@ void AutoAimTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 	//cam += newVel * playerInfo.ticktime;
 
 	Vector target;
-	if (params->entity) {
-		CEntInfo *entity = entityList->QuerySelector(params->ent_selector.c_str());
+	if (params.entity) {
+		CEntInfo *entity = entityList->QuerySelector(params.ent_selector.c_str());
 		
 		if (entity != NULL) target = ((ServerEnt*)entity->m_pEntity)->abs_origin();
 		else target = Vector{0, 0, 0};
 	} else {
-		target = params->point;
+		target = params.point;
 	}
 
 	Vector forward = target - cam;
@@ -141,19 +108,19 @@ void AutoAimTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 	pitch *= 180.0f / M_PI;
 	yaw *= 180.0f / M_PI;
 
-	bulk.viewAnalog = GetInterpolatedViewAnalog(
+	bulk.viewAnalog = AngleToolsUtils::GetInterpolatedViewAnalog(
 		QAngleToVector(playerInfo.angles), 
 		Vector{pitch, yaw}, 
-		params->easingTicks, 
+		params.easingTicks, 
 		elapsedTicks, 
-		params->easingType
+		params.easingType
 	);
 
 	if (sar_tas_debug.GetBool()) {
 		console->Print("autoaim pitch:%.2f yaw:%.2f\n", pitch, yaw);
 	}
 
-	if (elapsedTicks < params->easingTicks) {
+	if (elapsedTicks < params.easingTicks) {
 		++elapsedTicks;
 	}
 

--- a/src/Features/Tas/TasTools/AutoAimTool.hpp
+++ b/src/Features/Tas/TasTools/AutoAimTool.hpp
@@ -3,9 +3,12 @@
 #include "../TasTool.hpp"
 
 class AutoAimTool : public TasTool {
+private:
+	int elapsedTicks;
 public:
 	AutoAimTool(int slot)
-		: TasTool("autoaim", slot) {}
+		: TasTool("autoaim", slot)
+		, elapsedTicks(0) {}
 
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &bulk, const TasPlayerInfo &pInfo);

--- a/src/Features/Tas/TasTools/AutoAimTool.hpp
+++ b/src/Features/Tas/TasTools/AutoAimTool.hpp
@@ -1,16 +1,42 @@
 #pragma once
 
 #include "../TasTool.hpp"
+#include "Utils/SDK/Math.hpp"
+#include "Features/Tas/TasTools/AngleToolsUtils.hpp"
 
-class AutoAimTool : public TasTool {
+struct AutoAimParams : public TasToolParams {
+	AutoAimParams()
+		: TasToolParams(false) {}
+
+	AutoAimParams(Vector point, int easingTicks, AngleToolsUtils::EasingType easingType)
+		: TasToolParams(true)
+		, entity(false)
+		, point(point)
+		, easingTicks(easingTicks)
+		, easingType(easingType) {}
+
+	AutoAimParams(std::string selector, int easingTicks, AngleToolsUtils::EasingType easingType)
+		: TasToolParams(true)
+		, entity(true)
+		, ent_selector(selector)
+		, easingTicks(easingTicks)
+		, easingType(easingType) {}
+
+	bool entity;
+	std::string ent_selector;
+	Vector point;
+	int easingTicks;
+	AngleToolsUtils::EasingType easingType;
+};
+
+class AutoAimTool : public TasToolWithParams<AutoAimParams> {
 private:
 	int elapsedTicks;
 public:
 	AutoAimTool(int slot)
-		: TasTool("autoaim", slot)
+		: TasToolWithParams("autoaim", slot)
 		, elapsedTicks(0) {}
 
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &bulk, const TasPlayerInfo &pInfo);
-	virtual void Reset();
 };

--- a/src/Features/Tas/TasTools/AutoJumpTool.cpp
+++ b/src/Features/Tas/TasTools/AutoJumpTool.cpp
@@ -3,6 +3,7 @@
 #include "Modules/Engine.hpp"
 #include "Modules/Server.hpp"
 #include "Features/Tas/TasParser.hpp"
+#include "Features/Tas/TasPlayer.hpp"
 
 AutoJumpTool autoJumpTool[2] = {{0}, {1}};
 

--- a/src/Features/Tas/TasTools/AutoJumpTool.cpp
+++ b/src/Features/Tas/TasTools/AutoJumpTool.cpp
@@ -8,8 +8,11 @@
 AutoJumpTool autoJumpTool[2] = {{0}, {1}};
 
 void AutoJumpTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &pInfo) {
-	auto ttParams = std::static_pointer_cast<AutoJumpToolParams>(this->params);
-	if (ttParams->enabled) {
+	if (this->updated) {
+		hasJumpedLastTick = false;
+	}
+
+	if (params.enabled) {
 		if (pInfo.grounded && !pInfo.ducked && !hasJumpedLastTick) {
 			bulk.buttonStates[TasControllerInput::Jump] = true;
 			hasJumpedLastTick = true;
@@ -29,9 +32,4 @@ std::shared_ptr<TasToolParams> AutoJumpTool::ParseParams(std::vector<std::string
 	bool arg = vp[0] == "on";
 
 	return std::make_shared<AutoJumpToolParams>(arg);
-}
-
-void AutoJumpTool::Reset() {
-	this->params = std::make_shared<AutoJumpToolParams>();
-	hasJumpedLastTick = false;
 }

--- a/src/Features/Tas/TasTools/AutoJumpTool.hpp
+++ b/src/Features/Tas/TasTools/AutoJumpTool.hpp
@@ -10,15 +10,14 @@ struct AutoJumpToolParams : public TasToolParams {
 	}
 };
 
-class AutoJumpTool : public TasTool {
+class AutoJumpTool : public TasToolWithParams<AutoJumpToolParams> {
 public:
 	AutoJumpTool(int slot)
-		: TasTool("autojump", slot) {
+		: TasToolWithParams("autojump", slot) {
 	}
 
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &bulk, const TasPlayerInfo &pInfo);
-	virtual void Reset();
 
 private:
 	bool hasJumpedLastTick = false;

--- a/src/Features/Tas/TasTools/CheckTool.cpp
+++ b/src/Features/Tas/TasTools/CheckTool.cpp
@@ -4,9 +4,6 @@
 
 #include <cmath>
 
-#define DEFAULT_POS_EPSILON 0.5
-#define DEFAULT_ANG_EPSILON 0.2
-
 Variable sar_tas_check_max_replays("sar_tas_check_max_replays", "15", 0, "Maximum replays for the 'check' TAS tool until it gives up.\n");
 Variable sar_tas_check_disable("sar_tas_check_disable", "0", "Globally disable the 'check' TAS tool.\n");
 
@@ -14,30 +11,28 @@ CheckTool tasCheckTool[2] = {{0}, {1}};
 
 
 void CheckTool::Apply(TasFramebulk &fb, const TasPlayerInfo &info) {
-	auto ttParams = std::static_pointer_cast<CheckToolParams>(params);
-
-	if (!ttParams->enabled) return;
+	if (!params.enabled) return;
 
 	if (sar_tas_check_disable.GetBool()) {
-		params->enabled = false;
+		params.enabled = false;
 		return;
 	}
 
 	bool shouldReplay = false;
 
-	if (ttParams->pos) {
-		Vector delta = info.position - *ttParams->pos;
-		if (delta.SquaredLength() > ttParams->posepsilon*ttParams->posepsilon) {
+	if (params.pos) {
+		Vector delta = info.position - *params.pos;
+		if (delta.SquaredLength() > params.posepsilon * params.posepsilon) {
 			console->Print("Position was %.2f units away from target!\n", delta.Length());
 			shouldReplay = true;
 		}
 	}
 
-	if (ttParams->ang) {
-		float pitchDelta = info.angles.x - ttParams->ang->x;
-		float yawDelta = info.angles.y - ttParams->ang->y;
+	if (params.ang) {
+		float pitchDelta = info.angles.x - params.ang->x;
+		float yawDelta = info.angles.y - params.ang->y;
 		float distSquared = pitchDelta*pitchDelta + yawDelta*yawDelta;
-		if (distSquared > ttParams->angepsilon*ttParams->angepsilon) {
+		if (distSquared > params.angepsilon * params.angepsilon) {
 			console->Print("Angle was %.2f degrees away from target!\n", sqrtf(distSquared));
 			shouldReplay = true;
 		}
@@ -54,7 +49,7 @@ void CheckTool::Apply(TasFramebulk &fb, const TasPlayerInfo &info) {
 		}
 	}
 
-	params->enabled = false;
+	params.enabled = false;
 }
 
 static Vector parsePos(const std::vector<std::string> &args, size_t idx) {
@@ -135,8 +130,4 @@ std::shared_ptr<TasToolParams> CheckTool::ParseParams(std::vector<std::string> v
 	}
 
 	return std::make_shared<CheckToolParams>(pos, ang, posepsilon ? *posepsilon : DEFAULT_POS_EPSILON, angepsilon ? *angepsilon : DEFAULT_ANG_EPSILON);
-}
-
-void CheckTool::Reset() {
-	params = std::make_shared<CheckToolParams>();
 }

--- a/src/Features/Tas/TasTools/CheckTool.cpp
+++ b/src/Features/Tas/TasTools/CheckTool.cpp
@@ -30,7 +30,7 @@ void CheckTool::Apply(TasFramebulk &fb, const TasPlayerInfo &info) {
 
 	if (params.ang) {
 		float pitchDelta = info.angles.x - params.ang->x;
-		float yawDelta = info.angles.y - params.ang->y;
+		float yawDelta = Math::AngleNormalize(info.angles.y - params.ang->y);
 		float distSquared = pitchDelta*pitchDelta + yawDelta*yawDelta;
 		if (distSquared > params.angepsilon * params.angepsilon) {
 			console->Print("Angle was %.2f degrees away from target!\n", sqrtf(distSquared));

--- a/src/Features/Tas/TasTools/CheckTool.hpp
+++ b/src/Features/Tas/TasTools/CheckTool.hpp
@@ -2,9 +2,14 @@
 #include "Features/Tas/TasPlayer.hpp"
 #include "Features/Tas/TasTool.hpp"
 
+#define DEFAULT_POS_EPSILON 0.5
+#define DEFAULT_ANG_EPSILON 0.2
+
 struct CheckToolParams : public TasToolParams {
 	CheckToolParams()
 		: TasToolParams()
+		, posepsilon(DEFAULT_POS_EPSILON)
+		, angepsilon(DEFAULT_ANG_EPSILON)
 	{}
 
 	CheckToolParams(std::optional<Vector> pos, std::optional<QAngle> ang, float posepsilon, float angepsilon)
@@ -17,15 +22,14 @@ struct CheckToolParams : public TasToolParams {
 	float angepsilon;
 };
 
-class CheckTool : public TasTool {
+class CheckTool : public TasToolWithParams<CheckToolParams> {
 public:
 	CheckTool(int slot)
-		: TasTool("check", slot)
+		: TasToolWithParams("check", slot)
 	{}
 
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &fb, const TasPlayerInfo &info);
-	virtual void Reset();
 };
 
 extern CheckTool tasCheckTool[2];

--- a/src/Features/Tas/TasTools/DecelTool.cpp
+++ b/src/Features/Tas/TasTools/DecelTool.cpp
@@ -6,32 +6,20 @@
 #include "TasUtils.hpp"
 #include "StrafeTool.hpp"
 
-struct DecelParams : public TasToolParams {
-	DecelParams()
-		: TasToolParams() {}
-
-	DecelParams(float targetVel)
-		: TasToolParams(true)
-		, targetVel(targetVel) {}
-
-	float targetVel;
-};
 
 DecelTool decelTool[2] = {{0}, {1}};
 
 void DecelTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
-	auto params = std::static_pointer_cast<DecelParams>(this->params);
-
-	if (!params->enabled) {
+	if (!params.enabled) {
 		return;
 	}
 
-	float targetVel = params->targetVel;
+	float targetVel = params.targetVel;
 	float playerVel = autoStrafeTool[this->slot].GetGroundFrictionVelocity(playerInfo).Length2D(); 
 
 	// cant decelerate by accelerating lmfao
 	if (targetVel >= playerVel) {
-		params->enabled = false;
+		params.enabled = false;
 		return;
 	}
 
@@ -45,7 +33,7 @@ void DecelTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 	if (playerVel - targetVel < maxAccel) {
 		bulk.moveAnalog = bulk.moveAnalog.Normalize() * ((playerVel - targetVel) / maxAccel);
 		// dont need to decelerate next tick
-		params->enabled = false;
+		params.enabled = false;
 	}
 
 
@@ -71,8 +59,4 @@ std::shared_ptr<TasToolParams> DecelTool::ParseParams(std::vector<std::string> a
 	}
 
 	return std::make_shared<DecelParams>(targetVel);
-}
-
-void DecelTool::Reset() {
-	params = std::make_shared<TasToolParams>();
 }

--- a/src/Features/Tas/TasTools/DecelTool.hpp
+++ b/src/Features/Tas/TasTools/DecelTool.hpp
@@ -2,11 +2,22 @@
 #include "Features/Tas/TasPlayer.hpp"
 #include "Features/Tas/TasTool.hpp"
 
-class DecelTool : public TasTool {
+struct DecelParams : public TasToolParams {
+	DecelParams()
+		: TasToolParams() {}
+
+	DecelParams(float targetVel)
+		: TasToolParams(true)
+		, targetVel(targetVel) {}
+
+	float targetVel;
+};
+
+
+class DecelTool : public TasToolWithParams<DecelParams> {
 public:
 	DecelTool(int slot)
-		: TasTool("decel", slot) {}
+		: TasToolWithParams("decel", slot) {}
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &fb, const TasPlayerInfo &pInfo);
-	virtual void Reset();
 };

--- a/src/Features/Tas/TasTools/SetAngleTool.cpp
+++ b/src/Features/Tas/TasTools/SetAngleTool.cpp
@@ -16,15 +16,13 @@ struct SetAngleParams : public TasToolParams {
 		, pitch(pitch)
 		, yaw(yaw) 
 		, easingTicks(easingTicks) 
-		, easingType(easingType) 
-		, elapsedTicks(0) {}
+		, easingType(easingType) {}
 
 	float pitch;
 	float yaw;
 
 	int easingTicks;
 	EasingType easingType;
-	int elapsedTicks;
 };
 
 SetAngleTool setAngleTool[2] = {{0}, {1}};
@@ -36,7 +34,12 @@ void SetAngleTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 		return;
 	}
 
-	if (params->elapsedTicks >= params->easingTicks) {
+	if (this->updated) {
+		elapsedTicks = 0;
+		this->updated = false;
+	}
+
+	if (elapsedTicks >= params->easingTicks) {
 		params->enabled = false;
 		return;
 	}
@@ -45,7 +48,7 @@ void SetAngleTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 		QAngleToVector(playerInfo.angles),
 		Vector{params->pitch, params->yaw},
 		params->easingTicks,
-		params->elapsedTicks,
+		elapsedTicks,
 		params->easingType
 	);
 
@@ -53,7 +56,7 @@ void SetAngleTool::Apply(TasFramebulk &bulk, const TasPlayerInfo &playerInfo) {
 		console->Print("setang %.3f %.3f\n", bulk.viewAnalog.x, bulk.viewAnalog.y);
 	}
 
-	++params->elapsedTicks;
+	++elapsedTicks;
 }
 
 std::shared_ptr<TasToolParams> SetAngleTool::ParseParams(std::vector<std::string> vp) {

--- a/src/Features/Tas/TasTools/SetAngleTool.hpp
+++ b/src/Features/Tas/TasTools/SetAngleTool.hpp
@@ -1,17 +1,35 @@
 #pragma once
+
 #include "Features/Tas/TasPlayer.hpp"
 #include "Features/Tas/TasTool.hpp"
+#include "Features/Tas/TasTools/AngleToolsUtils.hpp"
 
+struct SetAngleParams : public TasToolParams {
+	SetAngleParams()
+		: TasToolParams() {}
 
-class SetAngleTool : public TasTool {
+	SetAngleParams(float pitch, float yaw, int easingTicks, AngleToolsUtils::EasingType easingType)
+		: TasToolParams(true)
+		, pitch(pitch)
+		, yaw(yaw) 
+		, easingTicks(easingTicks) 
+		, easingType(easingType) {}
+
+	float pitch;
+	float yaw;
+
+	int easingTicks;
+	AngleToolsUtils::EasingType easingType;
+};
+
+class SetAngleTool : public TasToolWithParams<SetAngleParams> {
 private:
 	int elapsedTicks;
 public:
 	SetAngleTool(int slot)
-		: TasTool("setang", slot)
+		: TasToolWithParams("setang", slot)
 		, elapsedTicks(0) {}
 
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &fb, const TasPlayerInfo &pInfo);
-	virtual void Reset();
 };

--- a/src/Features/Tas/TasTools/SetAngleTool.hpp
+++ b/src/Features/Tas/TasTools/SetAngleTool.hpp
@@ -4,9 +4,13 @@
 
 
 class SetAngleTool : public TasTool {
+private:
+	int elapsedTicks;
 public:
 	SetAngleTool(int slot)
-		: TasTool("setang", slot) {}
+		: TasTool("setang", slot)
+		, elapsedTicks(0) {}
+
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &fb, const TasPlayerInfo &pInfo);
 	virtual void Reset();

--- a/src/Features/Tas/TasTools/StrafeTool.cpp
+++ b/src/Features/Tas/TasTools/StrafeTool.cpp
@@ -36,7 +36,7 @@ void AutoStrafeTool::Apply(TasFramebulk &fb, const TasPlayerInfo &rawPInfo) {
 	bool compensatePitchMult = false;
 	if (!pInfo.grounded && fabsf(pInfo.angles.x - fb.viewAnalog.y) >= 30.0f) {
 		if (!asParams->noPitchLock) {
-			float signAng = tasPlayer->scriptVersion >= 6 ? (pInfo.angles.x - fb.viewAnalog.y) : pInfo.angles.x;
+			float signAng = tasPlayer->GetScriptVersion(slot) >= 6 ? (pInfo.angles.x - fb.viewAnalog.y) : pInfo.angles.x;
 			float diff = pInfo.angles.x - (29.9999f * (signAng / absOld(signAng)));
 			fb.viewAnalog.y = diff;
 		} else {
@@ -49,7 +49,7 @@ void AutoStrafeTool::Apply(TasFramebulk &fb, const TasPlayerInfo &rawPInfo) {
 	pInfo.angles.x -= fb.viewAnalog.y;
 
 	float velAngle = TasUtils::GetVelocityAngles(&pInfo).x;
-	if (pInfo.velocity.Length2D() == 0 && tasPlayer->scriptVersion >= 6) {
+	if (pInfo.velocity.Length2D() == 0 && tasPlayer->GetScriptVersion(slot) >= 6) {
 		if (this->updated && asParams->strafeDir.useVelAngle) {
 			velAngle = pInfo.angles.y;
 		} else {
@@ -90,7 +90,7 @@ void AutoStrafeTool::Apply(TasFramebulk &fb, const TasPlayerInfo &rawPInfo) {
 		if (pInfo.onSpeedPaint) fb.moveAnalog.x *= 2;
 	} else if (asParams->strafeType == AutoStrafeType::VECTORIAL_CAM) {
 		float lookAngle = this->shouldFollowLine ? asParams->strafeDir.angle : velAngle;
-		if (tasPlayer->scriptVersion >= 6) {
+		if (tasPlayer->GetScriptVersion(slot) >= 6) {
 			fb.viewAnalog.x -= lookAngle - pInfo.angles.y;
 		} else {
 			fb.viewAnalog.x = -(lookAngle - pInfo.angles.y);
@@ -312,9 +312,9 @@ float AutoStrafeTool::GetStrafeAngle(const TasPlayerInfo &player, AutoStrafePara
 
 		// forwardmove and sidemove were calculated incorrectly in v2 and older
 		// fix for newer, keep for older for backwards compability
-		if (tasPlayer->scriptVersion >= 3) {
+		if (tasPlayer->GetScriptVersion(slot) >= 3) {
 			float velAngle = TasUtils::GetVelocityAngles(&player).x;
-			if (player.velocity.Length2D() == 0 && tasPlayer->scriptVersion >= 6) velAngle = params.strafeDir.angle;
+			if (player.velocity.Length2D() == 0 && tasPlayer->GetScriptVersion(slot) >= 6) velAngle = params.strafeDir.angle;
 			float correctAng = (DEG2RAD(velAngle) + ang) - DEG2RAD(player.angles.y);
 			forwardmove = cosf(correctAng);
 			sidemove = -sinf(correctAng);
@@ -341,7 +341,7 @@ int AutoStrafeTool::GetTurningDirection(const TasPlayerInfo &pInfo, float desAng
 	auto asParams = std::static_pointer_cast<AutoStrafeParams>(params);
 
 	float velAngle = TasUtils::GetVelocityAngles(&pInfo).x;
-	if (pInfo.velocity.Length2D() == 0 && tasPlayer->scriptVersion >= 6) velAngle = desAngle;
+	if (pInfo.velocity.Length2D() == 0 && tasPlayer->GetScriptVersion(slot) >= 6) velAngle = desAngle;
 	float diff = desAngle - velAngle;
 	if (absOld(diff - 360) < absOld(diff)) diff -= 360;
 	if (absOld(diff + 360) < absOld(diff)) diff += 360;
@@ -350,7 +350,7 @@ int AutoStrafeTool::GetTurningDirection(const TasPlayerInfo &pInfo, float desAng
 		// we've reached our line!
 		// for newer script versions, disable veccam - we don't need it anymore
 		// BUT there is a better solution in a newer version lol
-		if (tasPlayer->scriptVersion >= 3) {
+		if (tasPlayer->GetScriptVersion(slot) >= 3) {
 			if (asParams->strafeType == VECTORIAL_CAM) {
 				asParams->strafeType = VECTORIAL;
 				this->switchedFromVeccam = true;
@@ -366,11 +366,11 @@ int AutoStrafeTool::GetTurningDirection(const TasPlayerInfo &pInfo, float desAng
 
 		// scale maxRotAng by surfaceFriction and make it slightly bigger, as the range
 		// is often surpassed by slowfly and some other shit I wasn't able to isolate
-		if (tasPlayer->scriptVersion >= 6) maxRotAng *= 2.0 / pInfo.surfaceFriction;
+		if (tasPlayer->GetScriptVersion(slot) >= 6) maxRotAng *= 2.0 / pInfo.surfaceFriction;
 
 		if (absOld(diff) > maxRotAng) {
 			this->shouldFollowLine = false;
-			if (tasPlayer->scriptVersion >= 6 && this->switchedFromVeccam) {
+			if (tasPlayer->GetScriptVersion(slot) >= 6 && this->switchedFromVeccam) {
 				asParams->strafeType = VECTORIAL_CAM;
 			}
 			this->switchedFromVeccam = false;
@@ -406,8 +406,8 @@ int AutoStrafeTool::GetTurningDirection(const TasPlayerInfo &pInfo, float desAng
 		// also remember that speedlock exists only when midair in versions 5 or newer
 		// also remember that aircontrol removes speedlock in versions 7 or newer
 		float airConLimit = (sar_aircontrol.GetBool() && server->AllowsMovementChanges()) ? INFINITY : 300.0f;
-		if (asParams->antiSpeedLock && tasPlayer->scriptVersion >= 4 && (!pInfo.grounded || tasPlayer->scriptVersion < 5)) {
-			if (pInfo.velocity.Length2D() < asParams->strafeSpeed.speed && pInfo.velocity.Length2D() >= (tasPlayer->scriptVersion >= 7 ? airConLimit : 300.0f)) {
+		if (asParams->antiSpeedLock && tasPlayer->GetScriptVersion(slot) >= 4 && (!pInfo.grounded || tasPlayer->GetScriptVersion(slot) < 5)) {
+			if (pInfo.velocity.Length2D() < asParams->strafeSpeed.speed && pInfo.velocity.Length2D() >= (tasPlayer->GetScriptVersion(slot) >= 7 ? airConLimit : 300.0f)) {
 
 				Vector wishDir(0, 1);
 				float maxSpeed = GetMaxSpeed(pInfo, wishDir);
@@ -432,7 +432,7 @@ int AutoStrafeTool::GetTurningDirection(const TasPlayerInfo &pInfo, float desAng
 		}
 
 		// last turn is used to detect reaching line. avoid false detection from avoiding speedlock
-		if (tasPlayer->scriptVersion < 6 || !speedLockAvoided) this->lastTurnDir = turnDir;
+		if (tasPlayer->GetScriptVersion(slot) < 6 || !speedLockAvoided) this->lastTurnDir = turnDir;
 		return turnDir;
 	}
 }

--- a/src/Features/Tas/TasTools/StrafeTool.hpp
+++ b/src/Features/Tas/TasTools/StrafeTool.hpp
@@ -54,13 +54,12 @@ struct AutoStrafeParams : public TasToolParams {
 };
 
 
-class AutoStrafeTool : public TasTool {
+class AutoStrafeTool : public TasToolWithParams<AutoStrafeParams> {
 public:
 	AutoStrafeTool(int slot)
-		: TasTool("strafe", slot){};
+		: TasToolWithParams("strafe", slot){};
 	virtual std::shared_ptr<TasToolParams> ParseParams(std::vector<std::string>);
 	virtual void Apply(TasFramebulk &fb, const TasPlayerInfo &pInfo);
-	virtual void Reset();
 
 	Vector followLinePoint;
 	bool shouldFollowLine = false;

--- a/src/Modules/FileSystem.cpp
+++ b/src/Modules/FileSystem.cpp
@@ -7,8 +7,14 @@
 #include "Surface.hpp"
 #include "Console.hpp"
 #include "Command.hpp"
+#include "Engine.hpp"
 
+#include <filesystem>
 #include <fstream>
+
+#ifndef _WIN32
+#	include <dirent.h>
+#endif
 
 FileSystem *fileSystem;
 
@@ -37,6 +43,42 @@ bool FileSystem::FileExistsSomewhere(std::string filename) {
 	}
 	return false;
 }
+
+#ifdef _WIN32
+std::string FileSystem::GetSaveDirectory() {
+	return engine->GetSaveDirName();
+}
+#else
+static std::string findSubCapitalization(const char *base, const char *sub) {
+	DIR *d = opendir(base);
+	if (!d) return std::string(sub);
+
+	struct dirent *ent;
+	while ((ent = readdir(d))) {
+		if (!strcasecmp(ent->d_name, sub)) {
+			closedir(d);
+			return std::string(ent->d_name);
+		}
+	}
+
+	closedir(d);
+	return std::string(sub);
+}
+// Apparently, GetSaveDirName has the wrong capitalization sometimes
+// kill me
+std::string FileSystem::GetSaveDirectory() {
+	std::string path = std::string(engine->GetGameDirectory()) + "/";
+	std::string dir = findSubCapitalization(path.c_str(), "save");
+	dir += (engine->GetSaveDirName() + 4);
+	return dir;
+}
+#endif
+
+bool FileSystem::MapExists(std::string name) {
+	name = "/maps/" + name + ".bsp";
+	return FileExistsSomewhere(name);
+}
+
 
 bool FileSystem::Init() {
 	g_pFullFileSystem = Interface::Create(this->Name(), "VFileSystem017", false);

--- a/src/Modules/FileSystem.hpp
+++ b/src/Modules/FileSystem.hpp
@@ -15,6 +15,8 @@ public:
 public:
 	std::vector<std::string> GetSearchPaths();
 	bool FileExistsSomewhere(std::string filename);
+	std::string GetSaveDirectory();
+	bool MapExists(std::string name);
 
 public:
 	bool Init() override;

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -198,21 +198,21 @@ DETOUR(Server::PlayerMove) {
 extern Hook g_playerRunCommandHook;
 // CPortal_Player::PlayerRunCommand
 DETOUR(Server::PlayerRunCommand, CUserCmd *cmd, void *moveHelper) {
+	int slot = server->GetSplitScreenPlayerSlot(thisptr);
+
 	if (!engine->IsGamePaused()) {
 		if (sar_tas_real_controller_debug.GetInt() == 3) {
-			auto playerInfo = tasPlayer->GetPlayerInfo<true>(thisptr, cmd);
+			auto playerInfo = tasPlayer->GetPlayerInfo(slot, thisptr, cmd);
 			console->Print("Jump input state at tick %d: %s\n", playerInfo.tick, (cmd->buttons & IN_JUMP) ? "true" : "false");
 		}
 	}
 
-	int slot = server->GetSplitScreenPlayerSlot(thisptr);
-
-	if (tasPlayer->IsActive() && tasPlayer->IsUsingTools(slot)) {
+	if (tasPlayer->IsActive() && tasPlayer->IsUsingTools()) {
 		tasPlayer->PostProcess(slot, thisptr, cmd);
 	}
 
 	if (tasPlayer->IsActive()) {
-		int tasTick = tasPlayer->GetPlayerInfo<true>(thisptr, cmd).tick - tasPlayer->GetStartTick();
+		int tasTick = tasPlayer->GetPlayerInfo(slot, thisptr, cmd).tick - tasPlayer->GetStartTick();
 		tasPlayer->DumpUsercmd(slot, cmd, tasTick, "server");
 
 		Vector pos = server->GetAbsOrigin(thisptr);
@@ -220,13 +220,13 @@ DETOUR(Server::PlayerRunCommand, CUserCmd *cmd, void *moveHelper) {
 		tasPlayer->DumpPlayerInfo(slot, tasTick, pos, eye_pos, cmd->viewangles);
 	}
 
-	Cheats::AutoStrafe(thisptr, cmd);
+	Cheats::AutoStrafe(slot, thisptr, cmd);
 
 	inputHud.SetInputInfo(slot, cmd->buttons, {cmd->sidemove, cmd->forwardmove, cmd->upmove});
 
 	strafeHud.SetData(slot, thisptr, cmd, true);
 
-	Cheats::PatchBhop(thisptr, cmd);
+	Cheats::PatchBhop(slot, thisptr, cmd);
 
 	// TAS playback overrides inputs, even if they're made by the map. 
 	// Allow Reloaded's +attack input for time portal.

--- a/src/Modules/Server.hpp
+++ b/src/Modules/Server.hpp
@@ -119,6 +119,9 @@ public:
 	// CServerGameDLL::GameFrame
 	DECL_DETOUR(GameFrame, bool simulating);
 
+	// CServerGameDLL::ApplyGameSettings
+	DECL_DETOUR(ApplyGameSettings, KeyValues *pKV);
+
 	// CGlobalEntityList::OnRemoveEntity
 	DECL_DETOUR_T(void, OnRemoveEntity, IHandleEntity *ent, CBaseHandle handle);
 

--- a/src/OffsetsData.hpp
+++ b/src/OffsetsData.hpp
@@ -171,6 +171,7 @@ OFFSET_DEFAULT(GetClientEntity, 3, 3)
 
 // CServerGameDLL
 OFFSET_DEFAULT(GameFrame, 4, 4)
+OFFSET_DEFAULT(ApplyGameSettings, 38, 38)
 OFFSET_DEFAULT(Think, 31, 31)
 OFFSET_DEFAULT(GetAllServerClasses, 10, 10)
 OFFSET_DEFAULT(IsRestoring, 24, 24)

--- a/src/SourceAutoRecord.vcxproj
+++ b/src/SourceAutoRecord.vcxproj
@@ -142,6 +142,8 @@
     <ClCompile Include="Features\Routing\Ruler.cpp" />
     <ClCompile Include="Features\SeasonalASCII.cpp" />
     <ClCompile Include="Features\Tas\TasTools\AngleToolsUtils.cpp" />
+    <ClCompile Include="Features\Tas\TasPlayer.cpp" />
+    <ClCompile Include="Features\Tas\TasScript.cpp" />
     <ClCompile Include="Features\WindowResizer.cpp" />
     <ClCompile Include="Games\ApertureTag.cpp" />
     <ClCompile Include="Games\Portal2.cpp" />
@@ -216,7 +218,6 @@
     <ClCompile Include="Features\AutoSubmit.cpp" />
     <ClCompile Include="Features\Tas\TasParser.cpp" />
     <ClCompile Include="Features\Tas\TasController.cpp" />
-    <ClCompile Include="Features\Tas\TasPlayer.cpp" />
     <ClCompile Include="Features\Tas\TasServer.cpp" />
     <ClCompile Include="Features\Tas\TasTool.cpp" />
     <ClCompile Include="Features\Tas\TasTools\AbsoluteMoveTool.cpp" />
@@ -329,6 +330,8 @@
     <ClInclude Include="Features\Routing\Ruler.hpp" />
     <ClInclude Include="Features\SeasonalASCII.hpp" />
     <ClInclude Include="Features\Tas\TasTools\AngleToolsUtils.hpp" />
+    <ClInclude Include="Features\Tas\TasPlayer.hpp" />
+    <ClInclude Include="Features\Tas\TasScript.hpp" />
     <ClInclude Include="Features\WindowResizer.hpp" />
     <ClInclude Include="Games\ApertureTag.hpp" />
     <ClInclude Include="Games\Portal2.hpp" />
@@ -399,7 +402,6 @@
     <ClInclude Include="Features\AutoSubmit.hpp" />
     <ClInclude Include="Features\Tas\TasParser.hpp" />
     <ClInclude Include="Features\Tas\TasController.hpp" />
-    <ClInclude Include="Features\Tas\TasPlayer.hpp" />
     <ClInclude Include="Features\Tas\TasServer.hpp" />
     <ClInclude Include="Features\Tas\TasTool.hpp" />
     <ClInclude Include="Features\Tas\TasTools\AbsoluteMoveTool.hpp" />

--- a/src/SourceAutoRecord.vcxproj.filters
+++ b/src/SourceAutoRecord.vcxproj.filters
@@ -316,9 +316,6 @@
     <ClCompile Include="Features\Tas\TasController.cpp">
       <Filter>SourceAutoRecord\Features\Tas</Filter>
     </ClCompile>
-    <ClCompile Include="Features\Tas\TasPlayer.cpp">
-      <Filter>SourceAutoRecord\Features\Tas</Filter>
-    </ClCompile>
     <ClCompile Include="Features\Tas\TasServer.cpp">
       <Filter>SourceAutoRecord\Features\Tas</Filter>
     </ClCompile>
@@ -489,6 +486,12 @@
     </ClCompile>
     <ClCompile Include="Features\Tas\TasTools\AngleToolsUtils.cpp">
       <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\Tas\TasPlayer.cpp">
+      <Filter>SourceAutoRecord\Features\Tas</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\Tas\TasScript.cpp">
+      <Filter>SourceAutoRecord\Features\Tas</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -915,9 +918,6 @@
     <ClInclude Include="Features\Tas\TasController.hpp">
       <Filter>SourceAutoRecord\Features\Tas</Filter>
     </ClInclude>
-    <ClInclude Include="Features\Tas\TasPlayer.hpp">
-      <Filter>SourceAutoRecord\Features\Tas</Filter>
-    </ClInclude>
     <ClInclude Include="Features\Tas\TasServer.hpp">
       <Filter>SourceAutoRecord\Features\Tas</Filter>
     </ClInclude>
@@ -1265,6 +1265,12 @@
     </ClInclude>
     <ClInclude Include="Features\Tas\TasTools\AngleToolsUtils.hpp">
       <Filter>SourceAutoRecord\Features\Tas\TasTools</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\Tas\TasPlayer.hpp">
+      <Filter>SourceAutoRecord\Features\Tas</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\Tas\TasScript.hpp">
+      <Filter>SourceAutoRecord\Features\Tas</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Added a way to send a TAS script through protocol, and receive raw scripts of sent TAS script. Additionally, fixed the issue where entity info packet expected larger data size than necessary. But I can't quite say if it wasn't working in the first place, since presumably noone has used that feature before or after merging.

It would be strongly appreciated if both of these functionalities were tested and confirmed working before merging this time. @RainbowwPhoenixx mentioned something about wanting to test it, but not sure if they found time to do that.