### PR TITLE
fix: orange demo angles

### DIFF
--- a/src/Modules/Engine.cpp
+++ b/src/Modules/Engine.cpp
@@ -203,11 +203,14 @@ bool Engine::IsCoop() {
 
 bool Engine::IsOrange() {
 	static bool isOrange;
-	if (session->signonState == SIGNONSTATE_FULL) {
+	if (engine->demoplayer->IsPlaying()) {
+		isOrange = GET_SLOT() == 1;
+	} else if (session->signonState == SIGNONSTATE_FULL) {
 		isOrange = this->IsCoop() && !engine->hoststate->m_activeGame && !engine->demoplayer->IsPlaying();
 	}
 	return isOrange;
 }
+
 bool Engine::IsSplitscreen() {
 	if (!engine->IsCoop()) return false;
 


### PR DESCRIPTION
because a. `engine->IsOrange()` is apparently false in orange demos, and
b. angles are apparently always stored in slot 0 in demos

Resolves: #169 