### PR TITLE
feat: draw cinematic camera path

### DIFF
--- a/src/Features/Camera.cpp
+++ b/src/Features/Camera.cpp
@@ -745,21 +745,6 @@ CON_COMMAND_F_COMPLETION(
 	}
 }
 
-CON_COMMAND(sar_cam_path_showkfs, "sar_cam_path_showkfs - display information about all camera path keyframes\n") {
-	if (!engine->demoplayer->IsPlaying())
-		return console->Print("Cinematic mode cannot be used outside of demo player.\n");
-
-	if (args.ArgC() == 1) {
-		for (auto const &state : camera->states) {
-			console->Print("%d: ", state.first);
-			console->Print(std::string(state.second).c_str());
-			console->Print("\n");
-		}
-	} else {
-		return console->Print(sar_cam_path_showkfs.ThisPtr()->m_pszHelpString);
-	}
-}
-
 CON_COMMAND(sar_cam_path_getkfs, "sar_cam_path_getkfs - exports commands for recreating currently made camera path\n") {
 	if (!engine->demoplayer->IsPlaying())
 		return console->Print("Cinematic mode cannot be used outside of demo player.\n");

--- a/src/Features/Camera.hpp
+++ b/src/Features/Camera.hpp
@@ -72,6 +72,7 @@ public:
 	bool IsDriving();
 	void OverrideView(CViewSetup *m_View);
 	CameraState InterpolateStates(float time);
+	void DrawInWorld() const;
 	void RequestTimeOffsetRefresh();
 	void RequestCameraRefresh();
 	void OverrideMovement(CUserCmd *cmd);


### PR DESCRIPTION
- Draws camera path
- Shows keyframe points in red, and current cinematic position in yellow, as lil' camera boxes
  - Of course, FOV, roll, and aspect ratio etc is taken into account when drawing them
- Controlled by `sar_cam_path_draw`, disabled by `sar_cam_control 2`
- Added `sar_cam_path_goto` to tp to a certain frame in drive mode
- **Removed `sar_cam_path_showkfs` in favor of `sar_cam_path_getkfs`**

See [P2SR Discord](https://discord.com/channels/146404426746167296/811780246608281650/1114185964995219527) for discussion, I settled on this shape for the lil' camera boxes
![It draws keyframes as little camera boxes](https://github.com/p2sr/SourceAutoRecord/assets/69196954/b9dde2da-9aff-47f0-aef2-60b97be84ada)
