### PR TITLE
fix: sar_get_partner_id

### DIFF
--- a/src/Features/ConfigPlus.cpp
+++ b/src/Features/ConfigPlus.cpp
@@ -717,7 +717,8 @@ static Condition *ParseCondition(std::queue<Token> toks) {
 // }}}
 
 CON_COMMAND_F(sar_get_partner_id, "sar_get_partner_id - Prints your coop partner's steam id\n", FCVAR_DONTRECORD) {
-	if (!engine->IsCoop() || engine->IsSplitscreen()) {
+	if (!engine->IsCoop() || engine->IsSplitscreen() || !strcmp("0", engine->GetPartnerSteamID32().c_str())) {
+		console->Print("This command only works in online co-op.\n");
 		return;
 	}
 	console->Print("%s\n", engine->GetPartnerSteamID32().c_str());

--- a/src/Features/Demo/GhostRenderer.cpp
+++ b/src/Features/Demo/GhostRenderer.cpp
@@ -116,8 +116,17 @@ void GhostRenderer::UpdateAnimatedVerts() {
 			localPos.x * yawSin + localPos.y * yawCos,
 			localPos.z
 		};
-		if (ghost->name == "Dinnerbone") {
+
+		if (ghost->name == "Dinnerbone" || ghost->name == "Grumm") {
 			localPos.z = 72 - localPos.z;
+		}
+
+		if (ghost->name == "jeb_") {
+			int host, server, client;
+			engine->GetTicks(host, server, client);
+
+			int hue = (server) % 360;
+			ghost->color = Utils::HSVToRGB(hue, 100, 100);
 		}
 
 		// transform it to global coordinates


### PR DESCRIPTION
Added a print upon succeeding if check, and added extra condition to if check. This condition was needed in the case where you are in a co-op game, then leave, and try to the run to command. Before it would just print "0" in console after doing so.