### PR TITLE
fix: InitCMFlagHook

### DIFF
--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -673,12 +673,13 @@ static void InitPlayerRunCommandHook() {
 }
 
 // CServerGameDLL::GameFrame
+ON_EVENT(SESSION_START) {
+	if (!IsAcceptInputTrampolineInitialized) InitAcceptInputTrampoline();
+	if ((!g_IsCMFlagHookInitialized) && (sv_bonus_challenge.GetBool())) InitCMFlagHook();
+	if (!g_IsPlayerRunCommandHookInitialized) InitPlayerRunCommandHook();
+}
 DETOUR(Server::GameFrame, bool simulating)
 {
-	if (!IsAcceptInputTrampolineInitialized) InitAcceptInputTrampoline();
-	if (!g_IsCMFlagHookInitialized) InitCMFlagHook();
-	if (!g_IsPlayerRunCommandHookInitialized) InitPlayerRunCommandHook();
-
 	if (sar_tick_debug.GetInt() >= 3 || (sar_tick_debug.GetInt() >= 2 && simulating)) {
 		int host, server, client;
 		engine->GetTicks(host, server, client);


### PR DESCRIPTION
Fixing `InitCMFlagHook` that happens every game tick outside of CM, significant improvement for cpu low1% fps.