### PR TITLE
Refactor: process movement events

### DIFF
--- a/src/Event.hpp
+++ b/src/Event.hpp
@@ -89,6 +89,7 @@ namespace Event {
 		bool server;
 		void *player;
 		CMoveData *move;
+		CUserCmd *cmd;
 		bool grounded;
 	};
 	template <>

--- a/src/Event.hpp
+++ b/src/Event.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "Utils.hpp"  // technically only Utils/SDK/GameMovement.hpp needed
+
 #include <functional>
 #include <string>
-#include "Utils.hpp" //technically only Utils/dsk/GameMovement.hpp needed
 
 #define _ON_INIT1(x)                                    \
 	static void _sar_init_fn_##x();                        \

--- a/src/Event.hpp
+++ b/src/Event.hpp
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <string>
+#include "Utils.hpp" //technically only Utils/dsk/GameMovement.hpp needed
 
 #define _ON_INIT1(x)                                    \
 	static void _sar_init_fn_##x();                        \
@@ -85,6 +86,9 @@ namespace Event {
 	struct EventData<PROCESS_MOVEMENT> {
 		int slot;
 		bool server;
+		void *player;
+		CMoveData *move;
+		bool grounded;
 	};
 	template <>
 	struct EventData<MAYBE_AUTOSUBMIT> {

--- a/src/Features/GroundFramesCounter.cpp
+++ b/src/Features/GroundFramesCounter.cpp
@@ -7,9 +7,6 @@
 #include "Modules/Console.hpp"
 #include "Modules/Engine.hpp"
 
-GroundFramesCounter *groundFramesCounter;
-
-
 GroundFramesCounter::GroundFramesCounter() {
 	this->hasLoaded = true;
 }
@@ -18,33 +15,31 @@ HUD_ELEMENT_MODE2(groundframes, "0", 0, 2, "Draws the number of ground frames si
 	ctx->DrawElement("groundframes: %d", groundFramesCounter->counter[ctx->slot]);
 }
 
-
-
 void GroundFramesCounter::HandleMovementFrame(int slot, bool grounded) {
 	if (pauseTimer->IsActive() && !engine->IsCoop() && !engine->demoplayer->IsPlaying()) return;
 
-	if (!GroundFramesCounter::grounded[slot] && grounded) {
-		GroundFramesCounter::AddToTotal(slot, GroundFramesCounter::counter[slot]);
+	if (!this->grounded[slot] && grounded) {
+		this->AddToTotal(slot, this->counter[slot]);
 	}
 
 	int hudMode = sar_hud_groundframes.GetInt();
 
-	if ((!GroundFramesCounter::grounded[slot] && grounded) || hudMode == 0) {
-		if (hudMode != 2) GroundFramesCounter::counter[slot] = 0;
+	if ((!this->grounded[slot] && grounded) || hudMode == 0) {
+		if (hudMode != 2) this->counter[slot] = 0;
 	} else if (grounded) {
-		GroundFramesCounter::counter[slot]++;
+		this->counter[slot]++;
 	}
 
-	GroundFramesCounter::grounded[slot] = grounded;
+	this->grounded[slot] = grounded;
 }
 
 void GroundFramesCounter::AddToTotal(int slot, int count) {
 	if (count >= MAX_GROUNDFRAMES_TRACK) return;
-	GroundFramesCounter::totals[slot][count] += 1;
+	this->totals[slot][count] += 1;
 }
 
 ON_EVENT(PROCESS_MOVEMENT) {
-	GroundFramesCounter::HandleMovementFrame(event.slot, event.grounded);
+	groundFramesCounter->HandleMovementFrame(event.slot, event.grounded);
 }
 
 CON_COMMAND(sar_groundframes_total, "sar_groundframes_total [slot] - output a summary of groundframe counts for the given player slot.\n") {
@@ -75,3 +70,5 @@ CON_COMMAND(sar_groundframes_reset, "sar_groundframes_reset - reset recorded gro
 HUD_ELEMENT_MODE2(grounded, "0", 0, 1, "Draws the state of player being on ground.\n", HudType_InGame | HudType_Paused | HudType_LoadingScreen) {
 	ctx->DrawElement("grounded: %s", groundFramesCounter->grounded[ctx->slot] ? "yes" : "no");
 }
+
+GroundFramesCounter *groundFramesCounter;

--- a/src/Features/GroundFramesCounter.cpp
+++ b/src/Features/GroundFramesCounter.cpp
@@ -1,5 +1,6 @@
 #include "GroundFramesCounter.hpp"
 
+#include "Event.hpp"
 #include "Features/Timer/PauseTimer.hpp"
 #include "Hud/Hud.hpp"
 #include "Modules/Client.hpp"
@@ -7,6 +8,7 @@
 #include "Modules/Engine.hpp"
 
 GroundFramesCounter *groundFramesCounter;
+
 
 GroundFramesCounter::GroundFramesCounter() {
 	this->hasLoaded = true;
@@ -16,27 +18,33 @@ HUD_ELEMENT_MODE2(groundframes, "0", 0, 2, "Draws the number of ground frames si
 	ctx->DrawElement("groundframes: %d", groundFramesCounter->counter[ctx->slot]);
 }
 
+
+
 void GroundFramesCounter::HandleMovementFrame(int slot, bool grounded) {
 	if (pauseTimer->IsActive() && !engine->IsCoop() && !engine->demoplayer->IsPlaying()) return;
 
-	if (!this->grounded[slot] && grounded) {
-		this->AddToTotal(slot, this->counter[slot]);
+	if (!GroundFramesCounter::grounded[slot] && grounded) {
+		GroundFramesCounter::AddToTotal(slot, GroundFramesCounter::counter[slot]);
 	}
 
 	int hudMode = sar_hud_groundframes.GetInt();
 
-	if ((!this->grounded[slot] && grounded) || hudMode == 0) {
-		if (hudMode != 2) this->counter[slot] = 0;
+	if ((!GroundFramesCounter::grounded[slot] && grounded) || hudMode == 0) {
+		if (hudMode != 2) GroundFramesCounter::counter[slot] = 0;
 	} else if (grounded) {
-		this->counter[slot]++;
+		GroundFramesCounter::counter[slot]++;
 	}
 
-	this->grounded[slot] = grounded;
+	GroundFramesCounter::grounded[slot] = grounded;
 }
 
 void GroundFramesCounter::AddToTotal(int slot, int count) {
 	if (count >= MAX_GROUNDFRAMES_TRACK) return;
-	this->totals[slot][count] += 1;
+	GroundFramesCounter::totals[slot][count] += 1;
+}
+
+ON_EVENT(PROCESS_MOVEMENT) {
+	GroundFramesCounter::HandleMovementFrame(event.slot, event.grounded);
 }
 
 CON_COMMAND(sar_groundframes_total, "sar_groundframes_total [slot] - output a summary of groundframe counts for the given player slot.\n") {

--- a/src/Features/GroundFramesCounter.hpp
+++ b/src/Features/GroundFramesCounter.hpp
@@ -6,16 +6,16 @@
 
 class GroundFramesCounter : public Feature {
 public:
-	static inline int counter[2] = {0};
-	static inline bool grounded[2] = {false};
-	static inline int totals[2][MAX_GROUNDFRAMES_TRACK] = {0};
+	int counter[2] = {0};
+	bool grounded[2] = {false};
+	int totals[2][MAX_GROUNDFRAMES_TRACK] = {0};
 
 public:
 	GroundFramesCounter();
-	static void HandleMovementFrame(int slot, bool grounded);
+	void HandleMovementFrame(int slot, bool grounded);
 
 private:
-	static void AddToTotal(int slot, int count);
+	void AddToTotal(int slot, int count);
 };
 
 extern GroundFramesCounter *groundFramesCounter;

--- a/src/Features/GroundFramesCounter.hpp
+++ b/src/Features/GroundFramesCounter.hpp
@@ -6,16 +6,16 @@
 
 class GroundFramesCounter : public Feature {
 public:
-	int counter[2] = {0};
-	bool grounded[2] = {false};
-	int totals[2][MAX_GROUNDFRAMES_TRACK] = {0};
+	static inline int counter[2] = {0};
+	static inline bool grounded[2] = {false};
+	static inline int totals[2][MAX_GROUNDFRAMES_TRACK] = {0};
 
 public:
 	GroundFramesCounter();
-	void HandleMovementFrame(int slot, bool grounded);
+	static void HandleMovementFrame(int slot, bool grounded);
 
 private:
-	void AddToTotal(int slot, int count);
+	static void AddToTotal(int slot, int count);
 };
 
 extern GroundFramesCounter *groundFramesCounter;

--- a/src/Features/Hud/PerformanceHud.cpp
+++ b/src/Features/Hud/PerformanceHud.cpp
@@ -129,15 +129,15 @@ void PerformanceHud::OnFrame(float frametime) {
 
 ON_EVENT(PRE_TICK) {
 	if (!sar_performance_hud.GetBool()) {
-		performanceHud.accum_ticks = 0;
+		performanceHud->accum_ticks = 0;
 		return;
 	}
-	performanceHud.accum_ticks++;
+	performanceHud->accum_ticks++;
 }
 
 CON_COMMAND(sar_performance_hud_clear, "Clears the performance HUD data.\n") {
-	performanceHud.frametimes_offTick.clear();
-	performanceHud.frametimes_onTick.clear();
+	performanceHud->frametimes_offTick.clear();
+	performanceHud->frametimes_onTick.clear();
 }
 
-PerformanceHud performanceHud;
+PerformanceHud *performanceHud;

--- a/src/Features/Hud/PerformanceHud.cpp
+++ b/src/Features/Hud/PerformanceHud.cpp
@@ -140,4 +140,4 @@ CON_COMMAND(sar_performance_hud_clear, "Clears the performance HUD data.\n") {
 	performanceHud->frametimes_onTick.clear();
 }
 
-PerformanceHud *performanceHud;
+PerformanceHud *performanceHud = new PerformanceHud();

--- a/src/Features/Hud/PerformanceHud.hpp
+++ b/src/Features/Hud/PerformanceHud.hpp
@@ -5,7 +5,7 @@
 class PerformanceHud : public Hud {
 public:
 	PerformanceHud()
-		: Hud(HudType_InGame | HudType_Paused | HudType_Menu | HudType_LoadingScreen, true){};
+		: Hud(HudType_InGame | HudType_Paused | HudType_Menu | HudType_LoadingScreen, true) {};
 
 	bool ShouldDraw() override;
 
@@ -16,11 +16,10 @@ public:
 	}
 
 	void OnFrame(float frametime);
-    
-    unsigned accum_ticks = 0;
-    std::vector<float> frametimes_offTick;
-    std::vector<float> frametimes_onTick;
 
+	unsigned accum_ticks = 0;
+	std::vector<float> frametimes_offTick;
+	std::vector<float> frametimes_onTick;
 };
 
-extern PerformanceHud performanceHud;
+extern PerformanceHud *performanceHud;

--- a/src/Features/Hud/RhythmGame.cpp
+++ b/src/Features/Hud/RhythmGame.cpp
@@ -17,7 +17,7 @@ bool RhythmGameHud::ShouldDraw() {
 }
 
 int RhythmGameHud::GetGroundframes() {
-	return groundframes;
+	return RhythmGameHud::groundframes;
 }
 
 bool prevGrounded = false;
@@ -130,4 +130,9 @@ void RhythmGameHud::OnJump(int slot) {
 	popups.push_back(popup);
 }
 
+ON_EVENT(PROCESS_MOVEMENT) {
+	if (!sar_rhythmgame.GetBool()) return; //can't use ShouldDraw because static
+	RhythmGameHud::HandleGroundframeLogic(event.slot, event.grounded);
+	if (event.move->m_nButtons & IN_JUMP && event.grounded) RhythmGameHud::OnJump(event.slot);
+}
 RhythmGameHud rhythmGameHud;

--- a/src/Features/Hud/RhythmGame.cpp
+++ b/src/Features/Hud/RhythmGame.cpp
@@ -129,4 +129,4 @@ ON_EVENT(PROCESS_MOVEMENT) {
 	if (event.move->m_nButtons & IN_JUMP && event.grounded) rhythmGameHud->OnJump(event.slot);
 }
 
-RhythmGameHud *rhythmGameHud;
+RhythmGameHud *rhythmGameHud = new RhythmGameHud();

--- a/src/Features/Hud/RhythmGame.cpp
+++ b/src/Features/Hud/RhythmGame.cpp
@@ -1,14 +1,14 @@
 #include "RhythmGame.hpp"
 
 #include "Event.hpp"
-#include "Variable.hpp"
-#include "Modules/Engine.hpp"
-#include "Modules/Client.hpp"
-#include "Modules/Surface.hpp"
 #include "Features/GroundFramesCounter.hpp"
 #include "Features/Session.hpp"
-#include "Modules/Scheme.hpp"
+#include "Modules/Client.hpp"
 #include "Modules/Console.hpp"
+#include "Modules/Engine.hpp"
+#include "Modules/Scheme.hpp"
+#include "Modules/Surface.hpp"
+#include "Variable.hpp"
 
 Variable sar_rhythmgame("sar_rhythmgame", "0", "Show a HUD indicating your groundframes as rhythm game like popups.\n");
 
@@ -16,24 +16,17 @@ bool RhythmGameHud::ShouldDraw() {
 	return sar_rhythmgame.GetBool();
 }
 
-int RhythmGameHud::GetGroundframes() {
-	return RhythmGameHud::groundframes;
-}
-
-bool prevGrounded = false;
 void RhythmGameHud::HandleGroundframeLogic(int slot, bool grounded) {
-	if (!prevGrounded && grounded) {
-		rhythmGameHud.groundframes = 0;
+	if (!this->was_grounded && grounded) {
+		this->groundframes = 0;
 	} else if (grounded) {
-		rhythmGameHud.groundframes++;
+		this->groundframes++;
 	}
 
-	prevGrounded = grounded;
+	this->was_grounded = grounded;
 }
 
 void RhythmGameHud::Paint(int slot) {
-	int screenWidth, screenHeight;
-	engine->GetScreenSize(nullptr, screenWidth, screenHeight);
 	auto font = scheme->GetFontByID(49);
 	float fh = surface->GetFontHeight(font);
 
@@ -88,7 +81,7 @@ void RhythmGameHud::Paint(int slot) {
 
 void RhythmGameHud::OnJump(int slot) {
 	int tick = session->GetTick();
-	int groundframes = GetGroundframes();
+	int groundframes = this->groundframes;
 
 	int screenWidth, screenHeight;
 	engine->GetScreenSize(nullptr, screenWidth, screenHeight);
@@ -131,8 +124,9 @@ void RhythmGameHud::OnJump(int slot) {
 }
 
 ON_EVENT(PROCESS_MOVEMENT) {
-	if (!sar_rhythmgame.GetBool()) return; //can't use ShouldDraw because static
-	RhythmGameHud::HandleGroundframeLogic(event.slot, event.grounded);
-	if (event.move->m_nButtons & IN_JUMP && event.grounded) RhythmGameHud::OnJump(event.slot);
+	if (!rhythmGameHud->ShouldDraw()) return;
+	rhythmGameHud->HandleGroundframeLogic(event.slot, event.grounded);
+	if (event.move->m_nButtons & IN_JUMP && event.grounded) rhythmGameHud->OnJump(event.slot);
 }
-RhythmGameHud rhythmGameHud;
+
+RhythmGameHud *rhythmGameHud;

--- a/src/Features/Hud/RhythmGame.hpp
+++ b/src/Features/Hud/RhythmGame.hpp
@@ -5,7 +5,7 @@
 class RhythmGameHud : public Hud {
 public:
 	RhythmGameHud()
-		: Hud(HudType_InGame, true){};
+		: Hud(HudType_InGame, true) {};
 
 	bool ShouldDraw() override;
 
@@ -15,11 +15,12 @@ public:
 		return false;
 	}
 
-	static void OnJump(int slot);
+	void OnJump(int slot);
 
-	static void HandleGroundframeLogic(int slot, bool grounded);
+	void HandleGroundframeLogic(int slot, bool grounded);
 
-	static inline int groundframes = 0;
+	int groundframes = 0;
+	bool was_grounded = false;
 
 	struct RhythmGamePopup {
 		int x;
@@ -30,16 +31,13 @@ public:
 		int streak;
 	};
 
-	static inline int perfectsInARow = 0;
+	int perfectsInARow = 0;
 
-	static inline std::vector<RhythmGamePopup> popups = std::vector<RhythmGamePopup>();
+	std::vector<RhythmGamePopup> popups;
 	Color perfectColor = Color{0, 171, 255, 0};  // 0 groundframes
-	Color goodColor = Color{0, 236, 82, 0};     // 1 groundframe
-	Color okColor = Color{127, 127, 127, 0};       // 2 groundframes
-	Color badColor = Color{216, 0, 0, 0};      // 3-6 groundframes
-
-private:
-	static int GetGroundframes();
+	Color goodColor = Color{0, 236, 82, 0};      // 1 groundframe
+	Color okColor = Color{127, 127, 127, 0};     // 2 groundframes
+	Color badColor = Color{216, 0, 0, 0};        // 3-6 groundframes
 };
 
-extern RhythmGameHud rhythmGameHud;
+extern RhythmGameHud *rhythmGameHud;

--- a/src/Features/Hud/RhythmGame.hpp
+++ b/src/Features/Hud/RhythmGame.hpp
@@ -15,11 +15,11 @@ public:
 		return false;
 	}
 
-	void OnJump(int slot);
+	static void OnJump(int slot);
 
-	void HandleGroundframeLogic(int slot, bool grounded);
+	static void HandleGroundframeLogic(int slot, bool grounded);
 
-	int groundframes = 0;
+	static inline int groundframes = 0;
 
 	struct RhythmGamePopup {
 		int x;
@@ -30,16 +30,16 @@ public:
 		int streak;
 	};
 
-	int perfectsInARow = 0;
+	static inline int perfectsInARow = 0;
 
-	std::vector<RhythmGamePopup> popups;
+	static inline std::vector<RhythmGamePopup> popups = std::vector<RhythmGamePopup>();
 	Color perfectColor = Color{0, 171, 255, 0};  // 0 groundframes
 	Color goodColor = Color{0, 236, 82, 0};     // 1 groundframe
 	Color okColor = Color{127, 127, 127, 0};       // 2 groundframes
 	Color badColor = Color{216, 0, 0, 0};      // 3-6 groundframes
 
 private:
-	int GetGroundframes();
+	static int GetGroundframes();
 };
 
 extern RhythmGameHud rhythmGameHud;

--- a/src/Features/Hud/ScrollSpeed.cpp
+++ b/src/Features/Hud/ScrollSpeed.cpp
@@ -83,12 +83,6 @@ void ClearLine(int slot, int line) {
 	}
 }
 
-ON_EVENT(SESSION_START) {
-	if (sar_scrollspeed.GetBool()){
-		if (g_jumpCounter[0]) clear(0);
-		if (g_jumpCounter[1]) clear(1);	
-	}
-}
 
 static inline int GetTickDifference(int slot, int lineIter, int jumpIter) {
 	return g_jumpTicks[slot][lineIter][jumpIter] - g_jumpTicks[slot][lineIter][jumpIter - 1];
@@ -227,10 +221,7 @@ void ScrollSpeedHud::Paint(int slot) {
 }
 
 void ScrollSpeedHud::OnJump(int slot, bool grounded) {
-	if (!this->ShouldDraw()) {
-		if (g_jumpCounter[slot]) clear(slot);
-		return;
-	}
+
 	int tick = session->GetTick();
 	int lastJumpIndex = BoundIndex(g_jumpCounter[slot] - 1, -1, MAX_CONSECUTIVE_SCROLL_INPUTS);
 	// Reset if it's been long enough
@@ -253,4 +244,18 @@ void ScrollSpeedHud::OnJump(int slot, bool grounded) {
 	}
 }
 
+ON_EVENT(SESSION_START) {
+	if (sar_scrollspeed.GetBool()) {
+		if (g_jumpCounter[0]) clear(0);
+		if (g_jumpCounter[1]) clear(1);
+	}
+}
+
+ON_EVENT(PROCESS_MOVEMENT) {
+	if (!sar_scrollspeed.GetBool()) {
+		if (g_jumpCounter[event.slot]) clear(event.slot);
+		return;
+	}
+	if (event.move->m_nButtons & IN_JUMP) ScrollSpeedHud::OnJump(event.slot, event.grounded);
+}
 ScrollSpeedHud scrollSpeedHud;

--- a/src/Features/Hud/ScrollSpeed.cpp
+++ b/src/Features/Hud/ScrollSpeed.cpp
@@ -221,12 +221,11 @@ void ScrollSpeedHud::Paint(int slot) {
 }
 
 void ScrollSpeedHud::OnJump(int slot, bool grounded) {
-
 	int tick = session->GetTick();
 	int lastJumpIndex = BoundIndex(g_jumpCounter[slot] - 1, -1, MAX_CONSECUTIVE_SCROLL_INPUTS);
 	// Reset if it's been long enough
 	if (tick > g_jumpTicks[slot][g_currentLine[slot]][lastJumpIndex] + CONSECUTIVE_END && g_jumpTicks[slot][g_currentLine[slot]][lastJumpIndex] > 0) {
-		g_jumpCounter[slot] = 1; 
+		g_jumpCounter[slot] = 1;
 		g_currentLine[slot] += 1;
 		if (g_currentLine[slot] >= MAX_INPUT_LINES) {
 			g_currentLine[slot] -= MAX_INPUT_LINES;
@@ -256,6 +255,7 @@ ON_EVENT(PROCESS_MOVEMENT) {
 		if (g_jumpCounter[event.slot]) clear(event.slot);
 		return;
 	}
-	if (event.move->m_nButtons & IN_JUMP) ScrollSpeedHud::OnJump(event.slot, event.grounded);
+	if (event.move->m_nButtons & IN_JUMP) scrollSpeedHud->OnJump(event.slot, event.grounded);
 }
-ScrollSpeedHud scrollSpeedHud;
+
+ScrollSpeedHud *scrollSpeedHud;

--- a/src/Features/Hud/ScrollSpeed.cpp
+++ b/src/Features/Hud/ScrollSpeed.cpp
@@ -258,4 +258,4 @@ ON_EVENT(PROCESS_MOVEMENT) {
 	if (event.move->m_nButtons & IN_JUMP) scrollSpeedHud->OnJump(event.slot, event.grounded);
 }
 
-ScrollSpeedHud *scrollSpeedHud;
+ScrollSpeedHud *scrollSpeedHud = new ScrollSpeedHud();

--- a/src/Features/Hud/ScrollSpeed.hpp
+++ b/src/Features/Hud/ScrollSpeed.hpp
@@ -13,10 +13,10 @@ public:
 		return false;
 	}
 
-	static void OnJump(int slot, bool grounded);
+	void OnJump(int slot, bool grounded);
 };
 
-extern ScrollSpeedHud scrollSpeedHud;
+extern ScrollSpeedHud *scrollSpeedHud;
 
 extern Variable sar_scrollspeed;
 extern Variable sar_scrollspeed_x;

--- a/src/Features/Hud/ScrollSpeed.hpp
+++ b/src/Features/Hud/ScrollSpeed.hpp
@@ -13,7 +13,7 @@ public:
 		return false;
 	}
 
-	void OnJump(int slot, bool grounded);
+	static void OnJump(int slot, bool grounded);
 };
 
 extern ScrollSpeedHud scrollSpeedHud;

--- a/src/Features/Hud/StrafeQuality.cpp
+++ b/src/Features/Hud/StrafeQuality.cpp
@@ -1,5 +1,6 @@
 #include "StrafeQuality.hpp"
 
+#include "Event.hpp"
 #include "Features/Session.hpp"
 #include "Features/Timer/PauseTimer.hpp"
 #include "Modules/Engine.hpp"
@@ -134,11 +135,6 @@ void StrafeQualityHud::OnUserCmd(int slot, const CUserCmd &cmd) {
 	g_lastMouseDeltas[slot] += cmd.mousedx;
 }
 void StrafeQualityHud::OnMovement(int slot, bool grounded) {
-	if (pauseTimer->IsActive() && !engine->IsCoop() && !engine->demoplayer->IsPlaying()) return;
-	if (!this->ShouldDraw()) {
-		if (!g_ticks[slot].empty()) ClearData(slot);
-		return;
-	}
 	CUserCmd &cmd = g_lastUserCmd[slot];
 
 	StrafeDir strafe =
@@ -166,4 +162,13 @@ void StrafeQualityHud::OnMovement(int slot, bool grounded) {
 		strafe,
 		mouseDelta,
 	});
+}
+
+ON_EVENT(PROCESS_MOVEMENT) {
+	if (pauseTimer->IsActive() && !engine->IsCoop() && !engine->demoplayer->IsPlaying()) return;
+	if (!sar_strafe_quality.GetBool()) {  //can't use ShouldDraw because static
+		if (!g_ticks[event.slot].empty()) ClearData(event.slot);
+		return;
+	}
+	StrafeQualityHud::OnMovement(event.slot, event.grounded);
 }

--- a/src/Features/Hud/StrafeQuality.cpp
+++ b/src/Features/Hud/StrafeQuality.cpp
@@ -30,8 +30,6 @@ static std::vector<TickInfo> g_ticks[2];
 static CUserCmd g_lastUserCmd[2];
 static int g_lastMouseDeltas[2];
 
-StrafeQualityHud strafeQuality;
-
 static Variable sar_strafe_quality("sar_strafe_quality", "0", "Enables or disables the strafe quality HUD.\n");
 static Variable sar_strafe_quality_ticks("sar_strafe_quality_ticks", "40", 10, "The number of ticks to average over for the strafe quality HUD.\n");
 static Variable sar_strafe_quality_width("sar_strafe_quality_width", "300", 10, "The width of the strafe quality HUD.\n");
@@ -166,9 +164,11 @@ void StrafeQualityHud::OnMovement(int slot, bool grounded) {
 
 ON_EVENT(PROCESS_MOVEMENT) {
 	if (pauseTimer->IsActive() && !engine->IsCoop() && !engine->demoplayer->IsPlaying()) return;
-	if (!sar_strafe_quality.GetBool()) {  //can't use ShouldDraw because static
+	if (!strafeQualityHud->ShouldDraw()) {
 		if (!g_ticks[event.slot].empty()) ClearData(event.slot);
 		return;
 	}
-	StrafeQualityHud::OnMovement(event.slot, event.grounded);
+	strafeQualityHud->OnMovement(event.slot, event.grounded);
 }
+
+StrafeQualityHud *strafeQualityHud;

--- a/src/Features/Hud/StrafeQuality.cpp
+++ b/src/Features/Hud/StrafeQuality.cpp
@@ -171,4 +171,4 @@ ON_EVENT(PROCESS_MOVEMENT) {
 	strafeQualityHud->OnMovement(event.slot, event.grounded);
 }
 
-StrafeQualityHud *strafeQualityHud;
+StrafeQualityHud *strafeQualityHud = new StrafeQualityHud();

--- a/src/Features/Hud/StrafeQuality.hpp
+++ b/src/Features/Hud/StrafeQuality.hpp
@@ -9,7 +9,7 @@ public:
 	bool GetCurrentSize(int &width, int &height) override;
 	void Paint(int slot) override;
 	void OnUserCmd(int slot, const CUserCmd &cmd);
-	void OnMovement(int slot, bool grounded);
+	static void OnMovement(int slot, bool grounded);
 };
 
 extern StrafeQualityHud strafeQuality;

--- a/src/Features/Hud/StrafeQuality.hpp
+++ b/src/Features/Hud/StrafeQuality.hpp
@@ -9,7 +9,7 @@ public:
 	bool GetCurrentSize(int &width, int &height) override;
 	void Paint(int slot) override;
 	void OnUserCmd(int slot, const CUserCmd &cmd);
-	static void OnMovement(int slot, bool grounded);
+	void OnMovement(int slot, bool grounded);
 };
 
-extern StrafeQualityHud strafeQuality;
+extern StrafeQualityHud *strafeQualityHud;

--- a/src/Modules/Client.cpp
+++ b/src/Modules/Client.cpp
@@ -267,7 +267,7 @@ DETOUR(Client::CreateMove, float flInputSampleTime, CUserCmd *cmd) {
 		synchro->UpdateSync(engine->IsOrange() ? 1 : 0, cmd);
 	}
 
-	strafeQuality.OnUserCmd(engine->IsOrange() ? 1 : 0, *cmd);
+	strafeQualityHud->OnUserCmd(engine->IsOrange() ? 1 : 0, *cmd);
 
 	if (cmd->buttons & IN_ATTACK) {
 		int slot = engine->IsOrange() ? 1 : 0;
@@ -290,7 +290,7 @@ DETOUR(Client::CreateMove2, float flInputSampleTime, CUserCmd *cmd) {
 		synchro->UpdateSync(1, cmd);
 	}
 
-	strafeQuality.OnUserCmd(1, *cmd);
+	strafeQualityHud->OnUserCmd(1, *cmd);
 
 	if (cmd->buttons & IN_ATTACK) {
 		g_bluePortalAngles[1] = engine->GetAngles(1);
@@ -531,12 +531,12 @@ DETOUR(Client::DecodeUserCmdFromBuffer, int nSlot, int buf, signed int sequence_
 		synchro->UpdateSync(nSlot, cmd);
 	}
 
-	strafeQuality.OnUserCmd(nSlot, *cmd);
+	strafeQualityHud->OnUserCmd(nSlot, *cmd);
 	void *player = client->GetPlayer(nSlot + 1);
 	if (player) {
 		bool grounded = CE(player)->ground_entity();
 		groundFramesCounter->HandleMovementFrame(nSlot, grounded);
-		strafeQuality.OnMovement(nSlot, grounded);
+		strafeQualityHud->OnMovement(nSlot, grounded);
 		strafeHud.SetData(nSlot, player, cmd, false);
 		Event::Trigger<Event::PROCESS_MOVEMENT>({nSlot, false});  // There isn't really one, just pretend it's here lol
 	}
@@ -715,10 +715,10 @@ DETOUR(Client::ProcessMovement, void *player, CMoveData *move) {
 			bool grounded = CE(player)->ground_entity();
 			slot = client->GetSplitScreenPlayerSlot(player);
 			groundFramesCounter->HandleMovementFrame(slot, grounded);
-			rhythmGameHud.HandleGroundframeLogic(slot, grounded);
-			strafeQuality.OnMovement(slot, grounded);
-			if (move->m_nButtons & IN_JUMP) scrollSpeedHud.OnJump(slot, grounded);
-			if (move->m_nButtons & IN_JUMP && grounded) rhythmGameHud.OnJump(slot);
+			rhythmGameHud->HandleGroundframeLogic(slot, grounded);
+			strafeQualityHud->OnMovement(slot, grounded);
+			if (move->m_nButtons & IN_JUMP) scrollSpeedHud->OnJump(slot, grounded);
+			if (move->m_nButtons & IN_JUMP && grounded) rhythmGameHud->OnJump(slot);
 				
 				
 			Event::Trigger<Event::PROCESS_MOVEMENT>({slot, false});

--- a/src/Modules/Client.cpp
+++ b/src/Modules/Client.cpp
@@ -535,10 +535,8 @@ DETOUR(Client::DecodeUserCmdFromBuffer, int nSlot, int buf, signed int sequence_
 	void *player = client->GetPlayer(nSlot + 1);
 	if (player) {
 		bool grounded = CE(player)->ground_entity();
-		groundFramesCounter->HandleMovementFrame(nSlot, grounded);
-		strafeQualityHud->OnMovement(nSlot, grounded);
 		strafeHud.SetData(nSlot, player, cmd, false);
-		Event::Trigger<Event::PROCESS_MOVEMENT>({nSlot, false});  // There isn't really one, just pretend it's here lol
+		Event::Trigger<Event::PROCESS_MOVEMENT>({nSlot, false, player, nullptr, cmd, grounded});  // There isn't really one, just pretend it's here lol
 	}
 
 	if (cmd->buttons & IN_ATTACK) {
@@ -714,14 +712,8 @@ DETOUR(Client::ProcessMovement, void *player, CMoveData *move) {
 		if (tick != lastTick) {
 			bool grounded = CE(player)->ground_entity();
 			slot = client->GetSplitScreenPlayerSlot(player);
-			groundFramesCounter->HandleMovementFrame(slot, grounded);
-			rhythmGameHud->HandleGroundframeLogic(slot, grounded);
-			strafeQualityHud->OnMovement(slot, grounded);
-			if (move->m_nButtons & IN_JUMP) scrollSpeedHud->OnJump(slot, grounded);
-			if (move->m_nButtons & IN_JUMP && grounded) rhythmGameHud->OnJump(slot);
-				
-				
-			Event::Trigger<Event::PROCESS_MOVEMENT>({slot, false});
+
+			Event::Trigger<Event::PROCESS_MOVEMENT>({slot, false, player, move, nullptr, grounded});
 			lastTick = tick;
 		}
 	}

--- a/src/Modules/Engine.cpp
+++ b/src/Modules/Engine.cpp
@@ -686,7 +686,7 @@ void Host_AccumulateTime_Detour(float dt);
 void (*Host_AccumulateTime)(float dt);
 static Hook Host_AccumulateTime_Hook(&Host_AccumulateTime_Detour);
 void Host_AccumulateTime_Detour(float dt) {
-	performanceHud.OnFrame(dt);
+	performanceHud->OnFrame(dt);
 	if (!g_advancing || !session->isRunning) {
 		Host_AccumulateTime_Hook.Disable();
 		Host_AccumulateTime(dt);

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -328,12 +328,7 @@ Hook g_ViewPunch_Hook(&Server::ViewPunch_Hook);
 DETOUR(Server::ProcessMovement, void *player, CMoveData *move) {
 	int slot = server->GetSplitScreenPlayerSlot(player);
 	bool grounded = SE(player)->ground_entity();
-	groundFramesCounter->HandleMovementFrame(slot, grounded);
-	rhythmGameHud.HandleGroundframeLogic(slot, grounded);
-	strafeQuality.OnMovement(slot, grounded);
-	if (move->m_nButtons & IN_JUMP) scrollSpeedHud.OnJump(slot, grounded);
-	if (move->m_nButtons & IN_JUMP && grounded) rhythmGameHud.OnJump(slot);
-	Event::Trigger<Event::PROCESS_MOVEMENT>({ slot, true });
+	Event::Trigger<Event::PROCESS_MOVEMENT>({ slot, true, player, move, grounded });
 
 	auto res = Server::ProcessMovement(thisptr, player, move);
 

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -328,7 +328,7 @@ Hook g_ViewPunch_Hook(&Server::ViewPunch_Hook);
 DETOUR(Server::ProcessMovement, void *player, CMoveData *move) {
 	int slot = server->GetSplitScreenPlayerSlot(player);
 	bool grounded = SE(player)->ground_entity();
-	Event::Trigger<Event::PROCESS_MOVEMENT>({ slot, true, player, move, grounded });
+	Event::Trigger<Event::PROCESS_MOVEMENT>({ slot, true, player, move, nullptr, grounded });
 
 	auto res = Server::ProcessMovement(thisptr, player, move);
 
@@ -759,7 +759,7 @@ Variable sar_fix_viewmodel_bug("sar_fix_viewmodel_bug", "0", "Fixes the viewmode
 ON_EVENT(SESSION_START) {
 	g_sendResetDoneAt = -1;
 
-	/* spawn viewmodel if it doesnt exist */
+	/* spawn viewmodel if it doesn't exist */
 	if (sar_fix_viewmodel_bug.GetBool())
 		if (CreateViewModel && !engine->IsCoop() && !entityList->GetEntityInfoByClassName("viewmodel") && !engine->demoplayer->IsPlaying())
 			CreateViewModel(server->GetPlayer(1), 0);


### PR DESCRIPTION
Moving Server::ProcessMovement function calls to process movement events so features' entry points are always standart.
Fixing Rhythmgame hud doing calculations when disabled