### PR TITLE
feat: Implement `sar_speedrun_triggers_info`

### DIFF
--- a/docs/cvars.md
+++ b/docs/cvars.md
@@ -524,6 +524,7 @@
 |sar_speedrun_stop|cmd|sar_speedrun_stop - stop the speedrun timer|
 |sar_speedrun_stop_in_menu|0|Automatically stop the speedrun timer when the menu is loaded.|
 |sar_speedrun_time_pauses|0|Include time spent paused in the speedrun timer.|
+|sar_speedrun_triggers_info|0|Print player velocity (and position) upon mtrigger activation.<br>1 - position and velocity<br>2 - only horizontal velocity|
 |sar_sr_hud|0|Draws speedrun timer.|
 |sar_sr_hud_font_color|255 255 255 255|RGBA font color of speedrun timer HUD.|
 |sar_sr_hud_font_index|70|Font index of speedrun timer HUD.|

--- a/src/Features/Speedrun/Categories.cpp
+++ b/src/Features/Speedrun/Categories.cpp
@@ -4,6 +4,7 @@
 #include "Event.hpp"
 #include "Features/Demo/DemoGhostPlayer.hpp"
 #include "Features/Hud/Hud.hpp"
+#include "Modules/Client.hpp"
 #include "Modules/Engine.hpp"
 #include "Modules/Server.hpp"
 #include "SpeedrunTimer.hpp"
@@ -122,11 +123,11 @@ static void dispatchRule(std::string name, SpeedrunRule *rule) {
 	int info = sar_speedrun_triggers_info.GetInt();
 	if (info == 0) return;
 
-	void *player = server->GetPlayer(1);
-	if (!player) return console->Print("Could not find player at slot 1.\n");
+	void *player = client->GetPlayer(GET_SLOT() + 1);
+	if (!player) return;
 
-	Vector pos = server->GetAbsOrigin(player);
-	Vector vel = server->GetLocalVelocity(player);
+	Vector pos = client->GetAbsOrigin(player);
+	Vector vel = client->GetLocalVelocity(player);
 
 	if (info == 1) {
 		// Info type 1 prints everything

--- a/src/Features/Speedrun/Categories.cpp
+++ b/src/Features/Speedrun/Categories.cpp
@@ -20,7 +20,7 @@
 #endif
 
 Variable sar_speedrun_draw_triggers("sar_speedrun_draw_triggers", "0", "Draw the triggers associated with speedrun rules in the world.\n");
-Variable sar_speedrun_triggers_info("sar_speedrun_triggers_info", "0", "Print player velocity (and position) upon zone trigger activation.\n1 - position and velocity\n2 - only horizontal velocity\n");
+Variable sar_speedrun_triggers_info("sar_speedrun_triggers_info", "0", "Print player velocity (and position) upon mtrigger activation.\n1 - position and velocity\n2 - only horizontal velocity\n");
 
 static std::optional<std::vector<std::string>> extractPartialArgs(const char *str, const char *cmd) {
 	while (*cmd) {
@@ -119,25 +119,23 @@ static void dispatchRule(std::string name, SpeedrunRule *rule) {
 	rule->fired = true;
 
 	// Handle `sar_speedrun_triggers_info`
-	if (rule->rule.index() == 1) { // Index 1 is ZoneTriggerRule
-		int info = sar_speedrun_triggers_info.GetInt();
-		if (info == 0) return;
+	int info = sar_speedrun_triggers_info.GetInt();
+	if (info == 0) return;
 
-		void *player = server->GetPlayer(1);
-		if (!player) return console->Print("Could not find player at slot 1.\n");
+	void *player = server->GetPlayer(1);
+	if (!player) return console->Print("Could not find player at slot 1.\n");
 
-		Vector pos = server->GetAbsOrigin(player);
-		Vector vel = server->GetLocalVelocity(player);
+	Vector pos = server->GetAbsOrigin(player);
+	Vector vel = server->GetLocalVelocity(player);
 
-		if (info == 1) {
-			// Info type 1 prints everything
-			console->Print("Player entered zone '%s':\n", name.c_str());
-			console->Print("  Position: %.2f %.2f %.2f\n", pos.x, pos.y, pos.z);
-			console->Print("  Velocity: %.2f %.2f %.2f\n", vel.x, vel.y, vel.z);
-		} else if (info == 2) {
-			// Info type 2 prints just the horizontal velocity
-			console->Print("Player entered zone with velocity: %.2f\n", vel.Length2D());
-		}
+	if (info == 1) {
+		// Info type 1 prints everything
+		console->Print("Player triggered rule '%s':\n", name.c_str());
+		console->Print("  Position: %.2f %.2f %.2f\n", pos.x, pos.y, pos.z);
+		console->Print("  Velocity: %.2f %.2f %.2f\n", vel.x, vel.y, vel.z);
+	} else if (info == 2) {
+		// Info type 2 prints just the horizontal velocity
+		console->Print("Player velocity on last rule: %.2f\n", vel.Length2D());
 	}
 }
 

--- a/src/Features/Speedrun/Categories.cpp
+++ b/src/Features/Speedrun/Categories.cpp
@@ -20,6 +20,7 @@
 #endif
 
 Variable sar_speedrun_draw_triggers("sar_speedrun_draw_triggers", "0", "Draw the triggers associated with speedrun rules in the world.\n");
+Variable sar_speedrun_triggers_info("sar_speedrun_triggers_info", "0", "Print player velocity (and position) upon zone trigger activation.\n1 - position and velocity\n2 - only horizontal velocity\n");
 
 static std::optional<std::vector<std::string>> extractPartialArgs(const char *str, const char *cmd) {
 	while (*cmd) {
@@ -116,6 +117,28 @@ static void dispatchRule(std::string name, SpeedrunRule *rule) {
 	}
 
 	rule->fired = true;
+
+	// Handle `sar_speedrun_triggers_info`
+	if (rule->rule.index() == 1) { // Index 1 is ZoneTriggerRule
+		int info = sar_speedrun_triggers_info.GetInt();
+		if (info == 0) return;
+
+		void *player = server->GetPlayer(1);
+		if (!player) return console->Print("Could not find player at slot 1.\n");
+
+		Vector pos = server->GetAbsOrigin(player);
+		Vector vel = server->GetLocalVelocity(player);
+
+		if (info == 1) {
+			// Info type 1 prints everything
+			console->Print("Player entered zone '%s':\n", name.c_str());
+			console->Print("  Position: %.2f %.2f %.2f\n", pos.x, pos.y, pos.z);
+			console->Print("  Velocity: %.2f %.2f %.2f\n", vel.x, vel.y, vel.z);
+		} else if (info == 2) {
+			// Info type 2 prints just the horizontal velocity
+			console->Print("Player entered zone with velocity: %.2f\n", vel.Length2D());
+		}
+	}
 }
 
 ON_EVENT(PRE_TICK) {


### PR DESCRIPTION
This was a feature [requested by Rattlé on Discord](https://discord.com/channels/146404426746167296/811780246608281650/1318579629254246400). This pull request adds the variable `sar_speedrun_triggers_info` which, when set, prints information about the player's position/velocity to the console once they activate a zone trigger speedrun rule.

If set to `1`, prints full rule name, position and velocity coordinates.
![image](https://github.com/user-attachments/assets/25f17512-258d-4263-a4a6-7fe82ab732ac)
If set to `2`, prints just the horizontal velocity on one line.
![image](https://github.com/user-attachments/assets/b6183859-e402-47fe-9b3a-72fa957b6b87)
