### PR TITLE
Clean up some trolling from the previous PR

### DIFF
--- a/src/Features/Hud/LPHud.cpp
+++ b/src/Features/Hud/LPHud.cpp
@@ -39,20 +39,21 @@ static int getCurrentCount() {
 // Get the current total portal count as reported by the the players'
 // m_StatsThisLevel values
 static int getStatsCount() {
-	if (!sar.game->Is(SourceGame_Portal2_2011)) {
-		int total = 0;
-
-		int slots = engine->GetMaxClients() >= 2 ? 2 : 1;
-		for (int slot = 0; slot < slots; ++slot) {
-			ClientEnt *player = client->GetPlayer(slot + 1);
-			if (!player) continue;
-			total += player->field<int>("iNumPortalsPlaced");
-		}
-
-		return total;
-	} else {
+	// this field doesn't seem to exist in 2011 Portal 2
+	if (sar.game->Is(SourceGame_Portal2_2011)) {
 		return 0;
 	}
+
+	int total = 0;
+
+	int slots = engine->GetMaxClients() >= 2 ? 2 : 1;
+	for (int slot = 0; slot < slots; ++slot) {
+		ClientEnt *player = client->GetPlayer(slot + 1);
+		if (!player) continue;
+		total += player->field<int>("iNumPortalsPlaced");
+	}
+
+	return total;
 }
 
 // Calculate an up-to-date total portal count using the player stats and

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -79,7 +79,7 @@ Game *Game::CreateNew() {
 
 	if (Utils::ICompare(modDir, Portal2::ModDir())) {
 		
-		void *engineClient = Interface::GetPtr(MODULE("engine"), "VEngineClient015", false);
+		void *engineClient = Interface::GetPtr(MODULE("engine"), "VEngineClient015");
 		if (engineClient) {
 			return new Portal2();
 		} else {

--- a/src/Interface.hpp
+++ b/src/Interface.hpp
@@ -61,7 +61,7 @@ public:
 	static Interface *Create(void *ptr, bool copyVtable = true, bool autoHook = true);
 	static Interface *Create(const char *filename, const char *interfaceSymbol, bool copyVtable = true, bool autoHook = true);
 	static void Delete(Interface *ptr);
-	static void *GetPtr(const char *filename, const char *interfaceSymbol, bool shouldTryLowerVersion = true);
+	static void *GetPtr(const char *filename, const char *interfaceSymbol);
 
 	template <typename T = void *>
 	static T Get(const char *filename, const char *interfaceSymbol) {

--- a/src/Modules/Client.cpp
+++ b/src/Modules/Client.cpp
@@ -500,7 +500,7 @@ DETOUR(Client::MsgFunc_SayText2, bf_read &msg) {
 			if (!c) break;
 		}
 	} else if (sar.game->Is(SourceGame_PortalReloaded | SourceGame_Portal2_2011)) {
-		// Reloaded uses the legacy format where it's just one string
+		// Reloaded and 2011 Portal 2 use the legacy format where it's just one string
 		while (true) {
 			char c = (char)(uint8_t)msg.ReadUnsigned(8);
 			if (!c) break;
@@ -1009,7 +1009,8 @@ bool Client::Init() {
 					this->g_HudChat->Hook(Client::MsgFunc_SayText2_Hook, Client::MsgFunc_SayText2, Offsets::MsgFunc_SayText2);
 					this->g_HudChat->Hook(Client::GetTextColorForClient_Hook, Client::GetTextColorForClient, Offsets::GetTextColorForClient);
 				} else if (sar.game->Is(SourceGame_PortalReloaded | SourceGame_Portal2_2011)) {
-					this->g_HudChat->Hook(Client::MsgFunc_SayText2_Hook, Client::MsgFunc_SayText2, Offsets::MsgFunc_SayTextReloaded);
+					// This hooks SayText, not SayText2, but the function signature is compatible
+					this->g_HudChat->Hook(Client::MsgFunc_SayText2_Hook, Client::MsgFunc_SayText2, Offsets::MsgFunc_SayText);
 				}
 			} else {
 				console->DevWarning("Failed to hook CHudChat\n");

--- a/src/Offsets/Portal 2 4554.hpp
+++ b/src/Offsets/Portal 2 4554.hpp
@@ -9,7 +9,7 @@ SIGSCAN_WINDOWS(MatrixBuildRotationAboutAxis, "55 8B EC 51 F3 0F 10 45 ? 0F 5A C
 // stolen from Infra
 SIGSCAN_WINDOWS(DrawTranslucentRenderables, "55 8B EC 81 EC 80 00 00 00 53 56 8B F1")
 
-// same as something else but I found myself
+// same as something else
 OFFSET_WINDOWS(HostState_OnClientConnected, 695)
 
 OFFSET_WINDOWS(gamerules, 5)
@@ -39,13 +39,17 @@ OFFSET_WINDOWS(GetSteamAPIContext, 176)
 //OFFSET_WINDOWS(HudUpdate, 11) // found, if needed
 //OFFSET_DEFAULT(IN_ActivateMouse, 15, 15) // verified
 //OFFSET_DEFAULT(IN_DeactivateMouse, 16, 16) // verified
-OFFSET_WINDOWS(ApplyMouse, 53) // found myself
+OFFSET_WINDOWS(ApplyMouse, 53) // found
 OFFSET_EMPTY(SteamControllerMove) // THIS DOES NOT EXIST IN 2011!!!! (because the Steam Controller didn't exist in 2011)
 //OFFSET_WINDOWS(JoyStickApplyMovement, 60) // found, if needed
 //OFFSET_DEFAULT(LevelInitPreEntity, 5, 5) // verified
 
 // CVEngineServer
 // all good
+
+// CHudChat/CBaseHudChat
+//OFFSET_WINDOWS(MsgFunc_SayText2, 27) // unused, see comment in latest P2 offsets file
+//OFFSET_WINDOWS(GetTextColorForClient, 32) // unused but ye
 
 // vgui stuff, pretty sure I just stole these from another version, no idea if they are correct,
 // but the game doesn't crash.
@@ -58,8 +62,8 @@ OFFSET_WINDOWS(UncacheUnusedMaterials, 76) // confirmed
 OFFSET_WINDOWS(CreateMaterial, 80) // confirmed
 OFFSET_WINDOWS(FindMaterial, 81) // confirmed
 OFFSET_WINDOWS(CreateProceduralTexture, 89) // confirmed
-OFFSET_WINDOWS(GetRenderContext, 111) // found myself
-OFFSET_WINDOWS(RemoveMaterial, 153) // found myself
+OFFSET_WINDOWS(GetRenderContext, 111) // found
+OFFSET_WINDOWS(RemoveMaterial, 153) // found
 
 // CEngineTool
 //OFFSET_DEFAULT(GetCurrentMap, 25, 26) // good
@@ -77,22 +81,22 @@ OFFSET_WINDOWS(PrecacheModel, 62)
 SIGSCAN_WINDOWS(ViewPunch, "55 8B EC A1 ? ? ? ? 83 EC 0C 83 78 ? 00 56 8B F1") // this works for 9568 too, maybe shorten that pattern/adjust to match this?
 
 // CBasePlayer
-OFFSET_WINDOWS(m_pShadowStand, 3156) // found myself
-OFFSET_WINDOWS(m_pShadowCrouch, 3160) // found myself
+OFFSET_WINDOWS(m_pShadowStand, 3156) // found
+OFFSET_WINDOWS(m_pShadowCrouch, 3160) // found
 
-OFFSET_WINDOWS(viewangles, 19112) // found myself
+OFFSET_WINDOWS(viewangles, 19112) // found
 
 // CBaseEntity
-OFFSET_WINDOWS(AcceptInput, 39) // found myself
-OFFSET_WINDOWS(IsPlayer, 84) // found myself
+OFFSET_WINDOWS(AcceptInput, 39) // found
+OFFSET_WINDOWS(IsPlayer, 84) // found
 
 // CPortal_Player
 //OFFSET_WINDOWS(GetPaintPower, 2) // this seems to be fine as is
-OFFSET_WINDOWS(PlayerRunCommand, 452) // found myself
-OFFSET_WINDOWS(UseSpeedPower, 508) // found myself
+OFFSET_WINDOWS(PlayerRunCommand, 452) // found
+OFFSET_WINDOWS(UseSpeedPower, 508) // found
 
 // CSteam3Client
-OFFSET_WINDOWS(OnGameOverlayActivated, 92)
+OFFSET_WINDOWS(OnGameOverlayActivated, 92) // found
 
 // IPhysicsObject
 // everything (should) be fine.
@@ -105,7 +109,7 @@ OFFSET_EMPTY(interfaceMgrOff)
 // all same as current P2
 
 // CDemoPlayer
-OFFSET_WINDOWS(SkipToTick, 14) // found myself
+OFFSET_WINDOWS(SkipToTick, 14) // found
 // rest are good
 
 // stolen
@@ -117,13 +121,13 @@ OFFSET_WINDOWS(m_bLoadGame, 440)
 
 SIGSCAN_WINDOWS(readConsoleCommandInjectSig, "8B 45 F4 50 68 ? 04 00 00 68 ? ? ? ? 8D 4D 90 E8 ? ? ? ? 8D 4F 04 E8") // needed to mask one byte
 
-OFFSET_WINDOWS(net_time, 21) // found myself
+OFFSET_WINDOWS(net_time, 21) // found
 
-OFFSET_WINDOWS(PerUserInput_tSize, 212) // found myself
-OFFSET_WINDOWS(m_pCommands, 224) // found myself
+OFFSET_WINDOWS(PerUserInput_tSize, 212) // found
+OFFSET_WINDOWS(m_pCommands, 224) // found
 // multiplayer_backup is good
 
 // check/refind these
-OFFSET_WINDOWS(m_pSurfaceData, 4088) // found myself but unsure
-OFFSET_WINDOWS(S_m_surfaceFriction, 4092) // found myself
-OFFSET_WINDOWS(C_m_surfaceFriction, 5532) // found myself
+OFFSET_WINDOWS(m_pSurfaceData, 4088) // found but unsure
+OFFSET_WINDOWS(S_m_surfaceFriction, 4092) // found
+OFFSET_WINDOWS(C_m_surfaceFriction, 5532) // found

--- a/src/Offsets/Portal 2 9568.hpp
+++ b/src/Offsets/Portal 2 9568.hpp
@@ -246,9 +246,13 @@ OFFSET_DEFAULT(ClientCommand, 39, 39)
 OFFSET_DEFAULT(ClientCommandKeyValues, 135, 135)
 OFFSET_DEFAULT(IsServerPaused, 81, 81)
 OFFSET_DEFAULT(ServerPause, 121, 121)
+
+// CHudChat/CBaseHudChat
 OFFSET_DEFAULT(ChatPrintf, 22, 25)
 OFFSET_DEFAULT(MsgFunc_SayText2, 28, 35)
-OFFSET_DEFAULT(MsgFunc_SayTextReloaded, 26, 32)
+// Portal 2 4554 and Reloaded need this offset and use the same value for it (latest P2's offset is 27 instead of 26).
+// Reloaded doesn't have its own offset file, so this is defined here
+OFFSET_DEFAULT(MsgFunc_SayText, 26, 32)
 OFFSET_DEFAULT(GetTextColorForClient, 33, 41)
 
 // CSteam3Client

--- a/src/SAR.cpp
+++ b/src/SAR.cpp
@@ -29,15 +29,15 @@ EXPOSE_SINGLE_INTERFACE_GLOBALVAR(SAR, IServerPluginCallbacks, INTERFACEVERSION_
 
 
 bool SAR::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceFn gameServerFactory) {
+	console = new Console();
+	if (!console->Init())
+		return false;
+	
 	modules = new Modules();
 	features = new Features();
 	cheats = new Cheats();
 	plugin = new Plugin();
 	game = Game::CreateNew();
-
-	console = new Console();
-	if (!console->Init())
-		return false;
 
 #ifdef _WIN32
 	// The auto-updater can create this file on Windows; we should try


### PR DESCRIPTION
This was meant to be a force push on the previous PR, but then the PR was merged 8 minutes before I went to go message AMJ to tell him not to merge yet (oops lol).

Anyways, made the thing in LPHud early return, demystified some memes with the MsgFunc_SayText(2) hook, and mostly undid/cleaned up the changes to Interface::GetPtr in favor of a simpler solution. (Related to that, the console module is now initialized first before any other modules, so that it is available immediately within the plugin.)

![image](https://github.com/user-attachments/assets/ea70981b-58b7-43aa-91ea-88cda6e81446)

In context to the above, it seems like when the NetMessage stuff for coop was first added, mlugg was originally writing it around SayText2 and then switched to SayText during feature dev without renaming it (or just mistakenly wrote SayText2 because the offset used [here](https://github.com/p2sr/SourceAutoRecord/commit/2791fa7f8865b2ae8815a7552a961e77cffcab83#diff-eaecd3b927bf0a13881d8788351be4d7212e861585b8d3e4876a358e211be1bfR257) was 100% for SayText, I downloaded a client.dll from that era and checked in Ghidra), and when the update came in 2022 that made the chat pretty or whatever (and shifted the vtable by 1), he [changed the offset](https://github.com/p2sr/SourceAutoRecord/commit/3e9e03aca8a805252c338b0f996bf2800ded5e1e#diff-eaecd3b927bf0a13881d8788351be4d7212e861585b8d3e4876a358e211be1bfR268) to actually match SayText2 for real, and probably had to change more code than was needed if it was just switched to the new SayText offset.

Anyways, perhaps some despaghettifying can occur on the SayText2 hook (I am not smart enough nor do I care enough to mess with this myself) if Reloaded/2011 P2 and latest P2 are unified to all use SayText, or SayText2, rather Reloaded/2011 using SayText, and latest P2 using SayText2.