### PR TITLE
Check m_hFiredByPlayer when tracking portal rules

### DIFF
--- a/src/Features/Speedrun/Rules.cpp
+++ b/src/Features/Speedrun/Rules.cpp
@@ -513,6 +513,12 @@ void SpeedrunTimer::TickRules() {
 				continue;
 			}
 
+			auto fromPlayer = SE(portal)->field<CBaseHandle>("m_hFiredByPlayer");
+			if (!fromPlayer) {
+				portalPositions[slot][i] = {};
+				continue;
+			}
+
 			bool activated = SE(portal)->field<bool>("m_bActivated");
 			if (!activated) {
 				portalPositions[slot][i] = {};


### PR DESCRIPTION
The `SpeedrunTimer::TickRules` function seemingly attempts to track only those portals shot by players, as evidenced by the queries for a player handle, followed by queries for the weapon handle. However, this is not an exhaustive check, and can lead to false positives in some cases.

For example, if the player has a single-portal device, a secondary linked portal opened via map logic will still count as being owned by the player's portal gun. This is likely because the portal gun is still _linked_ to that orange portal, despite not being able to create it. This becomes an issue in cases where SAR's demo data is used to count portal placements in custom maps.

To fix this, I've added a check for the `m_hFiredByPlayer` handle of the portal, which seems to only be valid when the portal has actually been fired by a player wielding a portal gun. I've tested this and confirmed that it works as intended on a [workshop map](https://steamcommunity.com/sharedfiles/filedetails/?id=1480459745) that would typically be susceptible to the false positive edge case mentioned earlier.
