### PR TITLE
feat: loading dots on coop map loads

### DIFF
--- a/docs/cvars.md
+++ b/docs/cvars.md
@@ -673,6 +673,7 @@
 |sar_twitch_chat_channel||The Twitch channel to connect to.|
 |sar_twitch_chat_color|255 255 255|The color of the Twitch chat messages.|
 |sar_twitch_chat_enabled|0|Enables Twitch chat integration.|
+|sar_ui_coop_dots|0|Toggles the loading screen dots during map transitions in coop.|
 |sar_unlocked_chapters|-1|Max unlocked chapter.|
 |sar_update|cmd|sar_update [release\|pre\|canary] [exit\|restart] [force] - update SAR to the latest version. If exit is given, exit the game upon successful update; if force is given, always re-install, even if it may be a downgrade|
 |sar_velocitygraph|0|Shows velocity graph.|

--- a/docs/cvars.md
+++ b/docs/cvars.md
@@ -321,6 +321,7 @@
 |sar_list_ents|cmd|sar_list_ents - lists entities|
 |sar_list_server_classes|cmd|sar_list_server_classes - lists all server classes|
 |sar_load_delay|0|Delay for this number of milliseconds at the end of a load.|
+|sar_loads_coop_dots|0|Toggles the loading screen dots during map transitions in coop.|
 |sar_loads_norender|0|Temporarily set mat_norendering to 1 during loads|
 |sar_loads_uncap|0|Temporarily set fps_max to 0 during loads|
 |sar_lphud|0|Enables or disables the portals display on screen.|
@@ -673,7 +674,6 @@
 |sar_twitch_chat_channel||The Twitch channel to connect to.|
 |sar_twitch_chat_color|255 255 255|The color of the Twitch chat messages.|
 |sar_twitch_chat_enabled|0|Enables Twitch chat integration.|
-|sar_ui_coop_dots|0|Toggles the loading screen dots during map transitions in coop.|
 |sar_unlocked_chapters|-1|Max unlocked chapter.|
 |sar_update|cmd|sar_update [release\|pre\|canary] [exit\|restart] [force] - update SAR to the latest version. If exit is given, exit the game upon successful update; if force is given, always re-install, even if it may be a downgrade|
 |sar_velocitygraph|0|Shows velocity graph.|

--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -51,7 +51,7 @@ Variable sar_prevent_ehm("sar_prevent_ehm", "0", 0, 1, "Prevents Entity Handle M
 Variable sar_disable_weapon_sway("sar_disable_weapon_sway", "0", 0, 1, "Disables the viewmodel lagging behind.\n");
 Variable sar_disable_viewmodel_shadows("sar_disable_viewmodel_shadows", "0", 0, 1, "Disables the shadows on the viewmodel.\n");
 Variable sar_floor_reportals("sar_floor_reportals", "0", "Toggles floor reportals. Requires cheats.\n", FCVAR_CHEAT);
-Variable sar_ui_coop_dots("sar_ui_coop_dots", "0", "Toggles the loading screen dots during map transitions in coop.\n");
+Variable sar_loads_coop_dots("sar_loads_coop_dots", "0", "Toggles the loading screen dots during map transitions in coop.\n");
 
 Variable sv_laser_cube_autoaim;
 Variable ui_loadingscreen_transition_time;
@@ -516,10 +516,10 @@ void Cheats::CheckFloorReportals() {
 }
 
 void Cheats::CheckUICoopDots() {
-	bool enabled = sar_ui_coop_dots.GetBool();
+	bool enabled = sar_loads_coop_dots.GetBool();
 	if (enabled && (!g_coopLoadingDotsPatch || !g_coopLoadingDotsPatch->IsInit())) {
-		console->Print("sar_ui_coop_dots is not available.\n");
-		sar_ui_coop_dots.SetValue(0);
+		console->Print("sar_loads_coop_dots is not available.\n");
+		sar_loads_coop_dots.SetValue(0);
 		return;
 	}
 	if (enabled == g_coopLoadingDotsPatch->IsPatched()) {

--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -372,7 +372,7 @@ void Cheats::Init() {
 	}
 
 	g_coopLoadingDotsPatch = new Memory::Patch();
-	auto coopLoadingDotsBool = Memory::Scan(MODULE("client"), Offsets::LoadingProgress__SetupControlStatesInstruction) + Offsets::LoadingProgress__SetupControlStatesBoolOffset;
+	auto coopLoadingDotsBool = Memory::Scan(MODULE("client"), Offsets::LoadingProgress__SetupControlStatesInstruction, Offsets::LoadingProgress__SetupControlStatesBoolOffset);
 	if (coopLoadingDotsBool) {
 		unsigned char coopLoadingDotsBoolByte = 0x1;
 		g_coopLoadingDotsPatch->Execute(coopLoadingDotsBool, &coopLoadingDotsBoolByte, 1);

--- a/src/Cheats.cpp
+++ b/src/Cheats.cpp
@@ -396,6 +396,8 @@ void Cheats::Shutdown() {
 	
 	g_floorReportalPatch->Restore();
 	SAFE_DELETE(g_floorReportalPatch);
+	g_coopLoadingDotsPatch->Restore();
+	SAFE_DELETE(g_coopLoadingDotsPatch);
 }
 
 

--- a/src/Cheats.hpp
+++ b/src/Cheats.hpp
@@ -11,6 +11,7 @@ public:
 	static void AutoStrafe(int slot, void *player, CUserCmd *cmd);
 	static void EnsureSlopeBoost(const CHLMoveData *move, void *player, CGameTrace **tr);
 	static void CheckFloorReportals();
+	static void CheckUICoopDots();
 };
 
 extern Variable sar_autorecord;
@@ -32,6 +33,8 @@ extern Variable sar_patch_cfg;
 extern Variable sar_prevent_ehm;
 extern Variable sar_disable_weapon_sway;
 extern Variable sar_disable_viewmodel_shadows;
+extern Variable sar_floor_reportals;
+extern Variable sar_ui_coop_dots;
 
 extern Variable sv_laser_cube_autoaim;
 extern Variable ui_loadingscreen_transition_time;

--- a/src/Cheats.hpp
+++ b/src/Cheats.hpp
@@ -34,7 +34,7 @@ extern Variable sar_prevent_ehm;
 extern Variable sar_disable_weapon_sway;
 extern Variable sar_disable_viewmodel_shadows;
 extern Variable sar_floor_reportals;
-extern Variable sar_ui_coop_dots;
+extern Variable sar_loads_coop_dots;
 
 extern Variable sv_laser_cube_autoaim;
 extern Variable ui_loadingscreen_transition_time;

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -285,6 +285,7 @@ DETOUR(Server::PlayerRunCommand, CUserCmd *cmd, void *moveHelper) {
 
 	Cheats::AutoStrafe(slot, thisptr, cmd);
 	Cheats::CheckFloorReportals();
+	Cheats::CheckUICoopDots();
 
 	inputHud.SetInputInfo(slot, cmd->buttons, {cmd->sidemove, cmd->forwardmove, cmd->upmove});
 

--- a/src/Offsets/Portal 2 9568.hpp
+++ b/src/Offsets/Portal 2 9568.hpp
@@ -432,6 +432,9 @@ SIGSCAN_EMPTY(FindElementSig)
 SIGSCAN_DEFAULT(GetChapterProgress, "56 8B 35 ? ? ? ? 57 8B F9 FF D6 8B 10 8B C8",
                                     "55 89 E5 57 56 53 83 EC 0C E8 ? ? ? ? 83 EC 08 8B 10")
 
+    // TODO: Linux Support
+SIGSCAN_DEFAULT(LoadingProgress__SetupControlStatesInstruction, "66 C7 86 ? ? ? ? ? ? EB", "")
+OFFSET_DEFAULT(LoadingProgress__SetupControlStatesBoolOffset, 7, 0)
 
 // Engine
 SIGSCAN_DEFAULT(ParseSmoothingInfoSig, "55 8B EC 0F 57 C0 81 EC ? ? ? ? B9 ? ? ? ? 8D 85 ? ? ? ? EB", ""); // "cl_demosmootherpanel.cpp" xref -> CDemoSmootherPanel::ParseSmoothingInfo

--- a/src/Offsets/Portal 2 9568.hpp
+++ b/src/Offsets/Portal 2 9568.hpp
@@ -432,9 +432,8 @@ SIGSCAN_EMPTY(FindElementSig)
 SIGSCAN_DEFAULT(GetChapterProgress, "56 8B 35 ? ? ? ? 57 8B F9 FF D6 8B 10 8B C8",
                                     "55 89 E5 57 56 53 83 EC 0C E8 ? ? ? ? 83 EC 08 8B 10")
 
-    // TODO: Linux Support
-SIGSCAN_DEFAULT(LoadingProgress__SetupControlStatesInstruction, "66 C7 86 ? ? ? ? ? ? EB", "")
-OFFSET_DEFAULT(LoadingProgress__SetupControlStatesBoolOffset, 7, 0)
+SIGSCAN_DEFAULT(LoadingProgress__SetupControlStatesInstruction, "66 C7 86 ? ? ? ? ? ? EB", "66 89 83 ? ? ? ? E9 ? ? ? ? ? ? ? ? ? ? ? 85 F6") // "vgui/loading_screens/loadingscreen_coop" xref -> LoadingProgress::SetupControlStates -> m_bDrawProgress set to 0
+OFFSET_DEFAULT(LoadingProgress__SetupControlStatesBoolOffset, 7, 5)
 
 // Engine
 SIGSCAN_DEFAULT(ParseSmoothingInfoSig, "55 8B EC 0F 57 C0 81 EC ? ? ? ? B9 ? ? ? ? 8D 85 ? ? ? ? EB", ""); // "cl_demosmootherpanel.cpp" xref -> CDemoSmootherPanel::ParseSmoothingInfo


### PR DESCRIPTION
Enables the loading dots during transitions/loads in coop. Linux is not supported currently.