### PR TITLE
VPK information added to demos

### DIFF
--- a/src/Checksum.hpp
+++ b/src/Checksum.hpp
@@ -5,3 +5,4 @@
 
 bool AddDemoChecksum(const char *filename);
 void AddDemoFileChecksums();
+void AddDemoVpkChecksums();

--- a/src/Modules/EngineDemoPlayer.cpp
+++ b/src/Modules/EngineDemoPlayer.cpp
@@ -171,6 +171,7 @@ std::string EngineDemoPlayer::GetLevelName() {
 // 0x0E: entity slot serial changed
 // 0x0F: frametime cap detection
 // 0x10: queued commands
+// 0x11: VPK internal checksums
 void EngineDemoPlayer::CustomDemoData(char *data, size_t length) {
 	if (data[0] == 0x03 || data[0] == 0x04) {  // Entity input data
 		std::optional<int> slot;

--- a/src/Modules/EngineDemoRecorder.cpp
+++ b/src/Modules/EngineDemoRecorder.cpp
@@ -166,6 +166,7 @@ DETOUR(EngineDemoRecorder::SetSignonState, int state) {
 		RecordQueuedCommands();
 		engine->ExecuteCommand("echo \"SAR " SAR_VERSION " (Built " SAR_BUILT ")\"", true);
 		AddDemoFileChecksums();
+		AddDemoVpkChecksums();
 		/*
 		RecordInitialVal("host_timescale");
 		RecordInitialVal("m_yaw");


### PR DESCRIPTION
Due to rule updates a lil while back we can kinda tell if a vpk is legal based just on what directories it edits, and its whole file checksum. Thus if we just record those things then people (assuming they are following the rules) won't need to submit vpk files anymore (and mods can hopefully stop having to download as much bs).

Directory VPK files can contain a lot of directories so I added a whitelist. I went through all the major things I could think of, but there's probably more I haven't considered. Should be really easy to add to as time goes on.

- Worked on all the major mods (Aperture Tag/Mel/Reloaded)
- Plugin loading didn't seem impacted in any real capacity (I tried on a weaker computer). 
- I didn't test this on Linux at all O7

Parsing pseudocode:
```
if (sarDataType == 17 {
   const vpkFileCrc = readUint32();
   const vpkPath = readNullTerminatedString();
   const numEntries = readUint32();
   for (let i=0; i<numEntries; i++) {
      let crc = readUint32();
      let path = readNullTerminatedString();
   }
}
```

