### PR TITLE
SAR Unload checksum fix

### DIFF
--- a/src/Modules/EngineDemoRecorder.cpp
+++ b/src/Modules/EngineDemoRecorder.cpp
@@ -37,6 +37,13 @@ int EngineDemoRecorder::GetTick() {
 	return this->GetRecordingTick(this->s_ClientDemoRecorder->ThisPtr());
 }
 
+// Stop any running demo so the SAR checksum is written to the demo file
+ON_EVENT(SAR_UNLOAD) {
+	if (engine->demorecorder->isRecordingDemo) {
+		engine->demorecorder->Stop();
+	}
+}
+
 std::string EngineDemoRecorder::GetDemoFilename() {
 #ifdef _WIN32
 #	define PATH_SEP "\\"


### PR DESCRIPTION
Fixes an issue where if the user quit (or unloaded the plugin) after the end of their run but before stopping the demo their checksum would not be recorded. This was mostly an issue with chapter runs.

Only tested on windows, but if this doesn't work on Linux somehow then snap me like a Slim jim™