### PR TITLE
Added an incomplete summary of current speedrun to demos

### DIFF
--- a/src/Features/Speedrun/SpeedrunTimer.cpp
+++ b/src/Features/Speedrun/SpeedrunTimer.cpp
@@ -592,6 +592,40 @@ static void recordDemoResult() {
 	engine->demorecorder->RecordData(data.data(), data.size());
 }
 
+static std::vector<uint8_t> buildIncompleteSummary() {
+	std::vector<uint8_t> data({0x12});
+
+	appendI32(g_speedrun.splits.size(), data);
+
+	for (SplitInfo split : g_speedrun.splits) {
+		appendStr(split.name, data);
+		appendI32(split.segments.size(), data);
+		for (Segment seg : split.segments) {
+			appendStr(seg.name, data);
+			appendI32(seg.ticks, data);
+		}
+	}
+
+	// category rules
+	appendI32(1, data);
+	auto rules = SpeedrunTimer::GetCategoryRules();
+	appendI32(rules.size(), data);
+	for (auto ruleName : rules) {
+		auto rule = SpeedrunTimer::GetRule(ruleName);
+		appendStr(ruleName, data);
+		appendStr(rule->Describe(), data);
+	}
+
+	return data;
+}
+
+void SpeedrunTimer::RecordIncompleteSummary() {
+	if (!SpeedrunTimer::IsRunning()) return;
+
+	std::vector<uint8_t> data = buildIncompleteSummary();
+	engine->demorecorder->RecordData(data.data(), data.size());
+}
+
 void SpeedrunTimer::Stop(std::string segName) {
 	if (!g_speedrun.isRunning) {
 		return;

--- a/src/Features/Speedrun/SpeedrunTimer.hpp
+++ b/src/Features/Speedrun/SpeedrunTimer.hpp
@@ -33,6 +33,8 @@ namespace SpeedrunTimer {
 
 	bool IsRunning();
 
+	void RecordIncompleteSummary();
+
 	void OnLoad();
 	void CategoryChanged();
 };  // namespace SpeedrunTimer

--- a/src/Modules/EngineDemoPlayer.cpp
+++ b/src/Modules/EngineDemoPlayer.cpp
@@ -172,6 +172,7 @@ std::string EngineDemoPlayer::GetLevelName() {
 // 0x0F: frametime cap detection
 // 0x10: queued commands
 // 0x11: VPK internal checksums
+// 0x12: incomplete speedrun summary
 void EngineDemoPlayer::CustomDemoData(char *data, size_t length) {
 	if (data[0] == 0x03 || data[0] == 0x04) {  // Entity input data
 		std::optional<int> slot;

--- a/src/Modules/EngineDemoRecorder.cpp
+++ b/src/Modules/EngineDemoRecorder.cpp
@@ -171,6 +171,7 @@ DETOUR(EngineDemoRecorder::SetSignonState, int state) {
 		needToRecordInitialVals = false;
 		RecordTimestamp();
 		RecordQueuedCommands();
+		SpeedrunTimer::RecordIncompleteSummary();
 		engine->ExecuteCommand("echo \"SAR " SAR_VERSION " (Built " SAR_BUILT ")\"", true);
 		AddDemoFileChecksums();
 		AddDemoVpkChecksums();


### PR DESCRIPTION
The idea behind this feature is to add a summary of the splits of this speedrun to every demo in the speedrun.

There are two main reasons this is desirable:
1. When people submit chapter runs from their full game runs, those demos don't include a speedrun summary, which can be a substantial inconvenience.
2. It provides proof of Gold vs. IL. The only real difference between a Gold and an IL PB is whether it occurred during a run. Previously, there was no way to verify that someone's demo actually came from a run without requiring them to provide a potentially full run's worth of demos.

The reason for using a new demo data type is mainly to avoid overcomplicating MDP. If we reused the same data type, the output would become unreadable since every demo would be cluttered with a summary. To avoid this, MDP would have to guess which demo is the final one in a run, which is outside the scope of that project. By using a separate data type, we can offer two distinct config options, allowing users to toggle incomplete summaries and complete summaries independently.