### PR TITLE
Added unique identifier generated per speedrun

### DIFF
--- a/src/Features/Speedrun/SpeedrunTimer.cpp
+++ b/src/Features/Speedrun/SpeedrunTimer.cpp
@@ -576,6 +576,7 @@ void SpeedrunTimer::Start() {
 		}
 	}
 	g_speedrun.hasSpeedrunId = true;
+	SpeedrunTimer::WriteIdToDemo();  // Write to current demo if recording
 
 	sendCoopPacket(PacketType::START);
 	if (!sar_mtrigger_legacy.GetBool()) {

--- a/src/Features/Speedrun/SpeedrunTimer.hpp
+++ b/src/Features/Speedrun/SpeedrunTimer.hpp
@@ -34,6 +34,7 @@ namespace SpeedrunTimer {
 	bool IsRunning();
 
 	void RecordIncompleteSummary();
+	void WriteIdToDemo();
 
 	void OnLoad();
 	void CategoryChanged();

--- a/src/Modules/EngineDemoPlayer.cpp
+++ b/src/Modules/EngineDemoPlayer.cpp
@@ -173,6 +173,7 @@ std::string EngineDemoPlayer::GetLevelName() {
 // 0x10: queued commands
 // 0x11: VPK internal checksums
 // 0x12: incomplete speedrun summary
+// 0x13: speedrun identifier
 void EngineDemoPlayer::CustomDemoData(char *data, size_t length) {
 	if (data[0] == 0x03 || data[0] == 0x04) {  // Entity input data
 		std::optional<int> slot;

--- a/src/Modules/EngineDemoRecorder.cpp
+++ b/src/Modules/EngineDemoRecorder.cpp
@@ -170,6 +170,7 @@ DETOUR(EngineDemoRecorder::SetSignonState, int state) {
 	if (state == SIGNONSTATE_FULL && needToRecordInitialVals) {
 		needToRecordInitialVals = false;
 		RecordTimestamp();
+		SpeedrunTimer::WriteIdToDemo();  // Write speedrun ID to every demo segment
 		RecordQueuedCommands();
 		SpeedrunTimer::RecordIncompleteSummary();
 		engine->ExecuteCommand("echo \"SAR " SAR_VERSION " (Built " SAR_BUILT ")\"", true);


### PR DESCRIPTION
Can improve some verification practices now and has potential to be even more useful in the future. 
Wanted both Blue and Orange's speedrun identifier to match for the speedrun they're both participating in because ofc it is the same speedrun. 
Chose to not modify the START message because that'd prob yield some weirdness if one person was on this SAR version and the other was on the previous and I didn't feel like dealing with that.

I tested AMC, CM, and No SLA. They all appeared to work fine (the identifiers were created, added to the demo, and matched in the case of coop).