### PR TITLE
Added sar_prevent_demo_lagspike

### DIFF
--- a/src/Offsets/Portal 2 9568.hpp
+++ b/src/Offsets/Portal 2 9568.hpp
@@ -449,6 +449,7 @@ SIGSCAN_DEFAULT(ResetToneMapping, "55 8B EC 83 EC 14 F3 0F 10 45 ?", "55 89 E5 5
 // Engine
 SIGSCAN_DEFAULT(ParseSmoothingInfoSig, "55 8B EC 0F 57 C0 81 EC ? ? ? ? B9 ? ? ? ? 8D 85 ? ? ? ? EB", ""); // "cl_demosmootherpanel.cpp" xref -> CDemoSmootherPanel::ParseSmoothingInfo
 OFFSET_DEFAULT(ParseSmoothingInfoOff, 178, -1)
+SIGSCAN_DEFAULT(ForceFullUpdate, "55 8B EC 56 8B F1 83 BE CC 00 00 00 FF 74 21 E8 ? ? ? ? 8B 45 08", "") // "cl_fullupdate" string xref -> ConCommand callback -> CClientState::ForceFullUpdate
 SIGSCAN_DEFAULT(Host_AccumulateTime, "55 8B EC 51 F3 0F 10 05 ? ? ? ? F3 0F 58 45 08 8B 0D ? ? ? ? F3 0F 11 05 ? ? ? ? 8B 01 8B 50 20 53 B3 01 FF D2",
                                      "83 EC 1C 8B 15 ? ? ? ? F3 0F 10 05 ? ? ? ? F3 0F 58 44 24 20 F3 0F 11 05 ? ? ? ? 8B 02 8B 40 24 3D ? ? ? ? 0F 85 41 03 00 00") // "-tools" -> function with 2 references -> Host_AccumulateTime
 SIGSCAN_DEFAULT(_Host_RunFrame_Render, "A1 ? ? ? ? 85 C0 75 1B 8B 0D ? ? ? ? 8B 01 8B 50 40 68 ? ? ? ? FF D2 A3 ? ? ? ? 85 C0 74 0D 6A 02 6A F6 50 E8 ? ? ? ? 83 C4 0C",


### PR DESCRIPTION
I don't mind if this one isn't merged, I just did like 99% of it before I accidentally proved my use-case invalid. 

Due to what was almost definitely a gross misreading of a conversation I had with Mlugg I was under the impression that the reason things break in Mel when demos are recording is due to the massive lag spike from the force update. 

My thought process was that the lag spike occurs because the game is syncing up the client and the server so playback is accurate. SO if we just don't care about demo playback we can tell it to not do that syncing process, prevent the lag spike, and get at least some demos for people to submit with Mel (which will at least contain some anti-cheat information and improve verification practices). 
During the process I found that there are actually two full updates right after each other. One happens just due to the demo being started, the other happens because of changes to the value of cl_localnetworkbackdoor. This is when I learned that actually demo recording only breaks stuff (the things I tested) due to cl_localnetworkbackdoor being set to 0. Unfortunately this invalidates my use-case as I don't think there's any real practical way to have demos not change the value of cl_localnetworkbackdoor other than just having it at 0 prior to the demo starting (which ofc breaks the level). 

The solution actually does work there are no lag spikes from demo recording after the cvar is changed (there is a one time one right when you change the cvar because it changes cl_localnetworkbackdoor to 0). The demos are also of course readable. Playback is broken but doesn't crash the game or anything, the game just fails the play them. 