### PR TITLE
Fixed vpk info sometimes appearing as file-data

### DIFF
--- a/src/Checksum.cpp
+++ b/src/Checksum.cpp
@@ -440,14 +440,16 @@ static void initFileSums() {
 						path.find("portal2_dlc1") == std::string::npos &&
 						path.find("portal2_dlc2") == std::string::npos;
 
+					bool isVpkDir = Utils::EndsWith(path, "_dir.vpk");
+
 					if (Utils::EndsWith(path, ".nut")
-						|| (Utils::EndsWith(path, ".vpk") && dlc)
+						|| (Utils::EndsWith(path, ".vpk") && dlc && !isVpkDir)
 						|| path.find("scripts/talker") != std::string::npos)
 					{
 						paths.push_back(path);
 					}
 					
-					if (Utils::EndsWith(path, "_dir.vpk")) {
+					if (isVpkDir) {
 						vpkDirPaths.push_back(path);
 					}
 				}


### PR DESCRIPTION
Thought I tested this issue before submitting the vpk-info PR. Might've missted it because I was installing modpacks the new way, or maybe I just wasn't being very thorough. Noticed it when testing the mdp update recently. 

# Issue
_dir.vpk files installed to dlc folders appear under file-data and vpk-information. That's bad and annoying from mdp's (and verifier's) perspective.  
To fix it I've changed it so that file-data ignores _dir.vpk files since the vpk-information is specifically made for them anyway.

### Demo-Testing
You'll notice that in the sar-update demo the _dir.vpk file doesn't appear as both a file and a vpk. 

demo: 'demos/sar-update.dem'
	'Betsruner' on sp_a2_bridge_the_gap - 60.00 TPS - 758 ticks
	events:
		[    0] [SAR] recorded at 2026/04/24 00:12:10 UTC
		[    0] [SAR] VPK "c:/program files (x86)/steam/steamapps/common/portal 2/portal2_dlc3/pak01_dir.vpk" has checksum 12D77D0E
			"materials/models/weapons/v_models/v_portalgun/v_portalgun.vtf" has checksum E5B5DA5D
	demo v2 checksum FAIL

demo: 'demos/sar1-15.dem'
	'Betsruner' on sp_a2_bridge_the_gap - 60.00 TPS - 1148 ticks
	events:
		[    0] [SAR] recorded at 2026/04/23 23:52:03 UTC
		[    0] [SAR] file "c:/program files (x86)/steam/steamapps/common/portal 2/portal2_dlc3/pak01_dir.vpk" has checksum 12D77D0E
		[    0] [SAR] VPK "c:/program files (x86)/steam/steamapps/common/portal 2/portal2_dlc3/pak01_dir.vpk" has checksum 12D77D0E
			"materials/models/weapons/v_models/v_portalgun/v_portalgun.vtf" has checksum E5B5DA5D
