### PR TITLE
Added vscript runtime checksum data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DEPS=$(OBJS:%.o=%.d)
 
 WARNINGS=-Wall -Wno-parentheses -Wno-unknown-pragmas -Wno-delete-non-virtual-dtor -Wno-overloaded-virtual
 CXXFLAGS=-std=c++17 -m32 $(WARNINGS) -I$(SDIR) -fPIC -D_GNU_SOURCE -Ilib/ffmpeg/include -Ilib/SFML/include -Ilib/curl/include -Ilib/discord-rpc/include -DSFML_STATIC -DCURL_STATICLIB
-LDFLAGS=-m32 -shared -lstdc++fs -Llib/ffmpeg/lib/linux -lavformat -lavcodec -lavutil -lswscale -lswresample -lx264 -lx265 -lvorbis -lvorbisenc -lvorbisfile -logg -lopus -lvpx -Llib/SFML/lib/linux -lsfml -Llib/curl/lib/linux -lcurl -lssl -lcrypto -lnghttp2 -Llib/discord-rpc/lib/linux -ldiscord-rpc
+LDFLAGS=-m32 -shared -lstdc++fs -Llib/ffmpeg/lib/linux -lavformat -lavcodec -lavutil -lswscale -lswresample -lx264 -lx265 -lvorbis -lvorbisenc -lvorbisfile -logg -lopus -lvpx -Llib/SFML/lib/linux -lsfml -Llib/curl/lib/linux -lcurl -lssl -lcrypto -lnghttp2 -Llib/discord-rpc/lib/linux -ldiscord-rpc -static-libstdc++ -static-libgcc
 
 # Import config.mk, which can be used for optional config
 -include config.mk

--- a/src/Checksum.cpp
+++ b/src/Checksum.cpp
@@ -27,6 +27,8 @@
 #define READ_LE32(arr, i) \
 	(((uint32_t)arr[i + 0] << 0) | ((uint32_t)arr[i + 1] << 8) | ((uint32_t)arr[i + 2] << 16) | ((uint32_t)arr[i + 3] << 24))
 
+static constexpr uint8_t SAR_MSG_VSCRIPT_RUNTIME_CHECKSUM = 0x14;
+
 // clang-format off
 static const uint32_t crcTable[256] = {
 	0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA,
@@ -505,6 +507,40 @@ static void addVpkInternalChecksum(const VpkInternalData &vpk) {
 	}
 
 	engine->demorecorder->RecordData(data.data(), data.size());
+}
+
+static size_t BoundedCStringLen(const char *str, size_t maxLen) {
+	if (!str) return 0;
+	size_t len = 0;
+	while (len < maxLen && str[len]) ++len;
+	return len;
+}
+
+void RecordRuntimeVscriptChecksum(const char *scriptName, const char *scriptData) {
+	if (!scriptName || !*scriptName || !scriptData || !*scriptData) return;
+
+	// Avoid an unbounded C-string search in case file data is not null-terminated.
+	constexpr size_t MAX_SCRIPT_SIZE = 8 * 1024 * 1024;
+	size_t scriptLen = BoundedCStringLen(scriptData, MAX_SCRIPT_SIZE);
+	if (scriptLen == 0) return;
+
+	uint32_t sum = 0;
+	if (scriptLen < MAX_SCRIPT_SIZE) {
+		sum = crc32(scriptData, scriptLen);
+	}
+
+	if (engine->demorecorder->isRecordingDemo && engine->demorecorder->GetTick() >= 0) {
+		size_t nameLen = strlen(scriptName);
+		size_t bufLen = nameLen + 6;
+		auto *buf = new uint8_t[bufLen];
+		buf[0] = SAR_MSG_VSCRIPT_RUNTIME_CHECKSUM;
+		*reinterpret_cast<uint32_t *>(buf + 1) = sum;
+		strcpy(reinterpret_cast<char *>(buf + 5), scriptName);
+		engine->demorecorder->RecordData(buf, bufLen);
+		delete[] buf;
+	} else {
+		engine->demorecorder->queuedVScriptChecksums.emplace_back(scriptName, sum);
+	}
 }
 
 void AddDemoVpkChecksums() {

--- a/src/Checksum.hpp
+++ b/src/Checksum.hpp
@@ -6,3 +6,4 @@
 bool AddDemoChecksum(const char *filename);
 void AddDemoFileChecksums();
 void AddDemoVpkChecksums();
+void RecordRuntimeVscriptChecksum(const char *scriptName, const char *scriptData);

--- a/src/Modules.hpp
+++ b/src/Modules.hpp
@@ -12,3 +12,4 @@
 #include "Modules/Tier1.hpp"
 #include "Modules/VGui.hpp"
 #include "Modules/VPhysics.hpp"
+#include "Modules/VScript.hpp"

--- a/src/Modules/Client.cpp
+++ b/src/Modules/Client.cpp
@@ -204,6 +204,7 @@ void Client::MultiColorChat(const std::vector<std::pair<Color, std::string>> &co
 }
 
 void Client::ShowLocator(Vector position, Vector normal, Color color) {
+	if (!PrecacheParticleSystem || !DispatchParticleEffect) return;
 	Vector colorAsVector = {(float)color.r, (float)color.g, (float)color.b};
 	QAngle angles;
 

--- a/src/Modules/EngineDemoPlayer.cpp
+++ b/src/Modules/EngineDemoPlayer.cpp
@@ -174,6 +174,7 @@ std::string EngineDemoPlayer::GetLevelName() {
 // 0x11: VPK internal checksums
 // 0x12: incomplete speedrun summary
 // 0x13: speedrun identifier
+// 0x14: runtime vscript checksum
 void EngineDemoPlayer::CustomDemoData(char *data, size_t length) {
 	if (data[0] == 0x03 || data[0] == 0x04) {  // Entity input data
 		std::optional<int> slot;

--- a/src/Modules/EngineDemoRecorder.cpp
+++ b/src/Modules/EngineDemoRecorder.cpp
@@ -104,6 +104,10 @@ static void RecordQueuedCommands() {
 }
 
 static void RecordQueuedVScriptChecksums() {
+	if (!engine->demorecorder->isRecordingDemo) return;
+	if (!engine->demorecorder->customDataReady) return;
+	if (engine->demorecorder->GetTick() < 0) return;
+
 	for (auto &queuedChecksum : engine->demorecorder->queuedVScriptChecksums) {
 		size_t nameLen = queuedChecksum.first.size();
 		size_t bufLen = nameLen + 6;
@@ -117,7 +121,15 @@ static void RecordQueuedVScriptChecksums() {
 	engine->demorecorder->queuedVScriptChecksums.clear();
 }
 
+ON_EVENT(PRE_TICK) {
+	if (!engine->demorecorder->queuedVScriptChecksums.empty()) {
+		RecordQueuedVScriptChecksums();
+	}
+}
+
 ON_EVENT(SESSION_END) {
+	engine->demorecorder->queuedVScriptChecksums.clear();
+
 	if (*engine->demorecorder->m_bRecording && sar_autorecord.GetInt() == -1) {
 		engine->demorecorder->Stop();
 	}

--- a/src/Modules/EngineDemoRecorder.cpp
+++ b/src/Modules/EngineDemoRecorder.cpp
@@ -103,6 +103,20 @@ static void RecordQueuedCommands() {
 	engine->demorecorder->queuedCommands.clear();
 }
 
+static void RecordQueuedVScriptChecksums() {
+	for (auto &queuedChecksum : engine->demorecorder->queuedVScriptChecksums) {
+		size_t nameLen = queuedChecksum.first.size();
+		size_t bufLen = nameLen + 6;
+		auto *buf = new uint8_t[bufLen];
+		buf[0] = 0x14;
+		*reinterpret_cast<uint32_t *>(buf + 1) = queuedChecksum.second;
+		strcpy(reinterpret_cast<char *>(buf + 5), queuedChecksum.first.c_str());
+		engine->demorecorder->RecordData(buf, bufLen);
+		delete[] buf;
+	}
+	engine->demorecorder->queuedVScriptChecksums.clear();
+}
+
 ON_EVENT(SESSION_END) {
 	if (*engine->demorecorder->m_bRecording && sar_autorecord.GetInt() == -1) {
 		engine->demorecorder->Stop();
@@ -172,6 +186,7 @@ DETOUR(EngineDemoRecorder::SetSignonState, int state) {
 		RecordTimestamp();
 		SpeedrunTimer::WriteIdToDemo();  // Write speedrun ID to every demo segment
 		RecordQueuedCommands();
+		RecordQueuedVScriptChecksums();
 		SpeedrunTimer::RecordIncompleteSummary();
 		engine->ExecuteCommand("echo \"SAR " SAR_VERSION " (Built " SAR_BUILT ")\"", true);
 		AddDemoFileChecksums();

--- a/src/Modules/EngineDemoRecorder.hpp
+++ b/src/Modules/EngineDemoRecorder.hpp
@@ -5,6 +5,8 @@
 #include "Utils.hpp"
 
 #include <string>
+#include <utility>
+#include <vector>
 
 // Ticks before demo autostop
 #define DEMO_AUTOSTOP_DELAY 15
@@ -28,6 +30,7 @@ public:
 	int autorecordStartNum = 1;
 
 	std::vector<std::string> queuedCommands = {};
+	std::vector<std::pair<std::string, uint32_t>> queuedVScriptChecksums = {};
 
 	char coopRadialMenuLastPos[8];
 

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -41,6 +41,7 @@
 #include "Offsets.hpp"
 #include "Utils.hpp"
 #include "Variable.hpp"
+#include "Utils/lodepng.hpp"
 
 #include "Features/OverlayRender.hpp"
 
@@ -336,6 +337,70 @@ static bool FindClosestPassableSpace_Detour(void *entity, const Vector &ind_push
 Hook FindClosestPassableSpace_Hook(&FindClosestPassableSpace_Detour);
 
 static int (*UTIL_GetCommandClientIndex)();
+static constexpr uint8_t SAR_MSG_VSCRIPT_RUNTIME_CHECKSUM = 0x14;
+
+static size_t BoundedCStringLen(const char *str, size_t maxLen) {
+	if (!str) return 0;
+	size_t len = 0;
+	while (len < maxLen && str[len]) ++len;
+	return len;
+}
+
+static void RecordRuntimeVscriptChecksum(const char *scriptName, const char *scriptData) {
+	if (!scriptName || !*scriptName || !scriptData || !*scriptData) return;
+
+	// Meant to avoid an unbounded C-String search in case a file data ever isn't null-terminated
+	constexpr size_t MAX_SCRIPT_SIZE = 8 * 1024 * 1024;
+	size_t scriptLen = BoundedCStringLen(scriptData, MAX_SCRIPT_SIZE);
+	if (scriptLen == 0) return;
+
+	uint32_t sum = 0;
+	if (scriptLen < MAX_SCRIPT_SIZE) {
+		sum = lodepng_crc32(reinterpret_cast<const unsigned char *>(scriptData), scriptLen);
+	}
+
+	if (engine->demorecorder->isRecordingDemo) {
+		size_t nameLen = strlen(scriptName);
+		size_t bufLen = nameLen + 6;
+		auto *buf = new uint8_t[bufLen];
+		buf[0] = SAR_MSG_VSCRIPT_RUNTIME_CHECKSUM;
+		*reinterpret_cast<uint32_t *>(buf + 1) = sum;
+		strcpy(reinterpret_cast<char *>(buf + 5), scriptName);
+		engine->demorecorder->RecordData(buf, bufLen);
+		delete[] buf;
+	} else {
+		engine->demorecorder->queuedVScriptChecksums.emplace_back(scriptName, sum);
+	}
+}
+
+#ifdef _WIN32
+using _VScript_CompileScript = int(__rescall *)(void *thisptr, const char *scriptData, const char *scriptName);
+#else
+using _VScript_CompileScript = int(__cdecl *)(void *thisptr, const char *scriptData, const char *scriptName);
+#endif
+static _VScript_CompileScript VScript_CompileScript;
+extern Hook g_VScriptCompileScriptHook;
+#ifdef _WIN32
+static int __fastcall VScript_CompileScript_Hook(void *thisptr, int edx, const char *scriptData, const char *scriptName)
+#else
+static int __cdecl VScript_CompileScript_Hook(void *thisptr, const char *scriptData, const char *scriptName)
+#endif
+{
+#ifdef _WIN32
+	(void)edx;
+#endif
+	(void)thisptr;
+
+	if (scriptName && *scriptName) {
+		RecordRuntimeVscriptChecksum(scriptName, scriptData);
+	}
+
+	g_VScriptCompileScriptHook.Disable();
+	auto ret = VScript_CompileScript(thisptr, scriptData, scriptName);
+	g_VScriptCompileScriptHook.Enable();
+	return ret;
+}
+Hook g_VScriptCompileScriptHook(&VScript_CompileScript_Hook);
 
 extern Hook g_ViewPunch_Hook;
 DETOUR_T(void, Server::ViewPunch, const QAngle &offset) {
@@ -969,6 +1034,20 @@ bool Server::Init() {
 	if (sar.game->Is(SourceGame_Portal2 | SourceGame_Portal2_2011)) {
 		Server::IsInPVS = (Server::_IsInPVS)Memory::Scan(this->Name(), Offsets::IsInPVS);
 		g_IsInPVS_Hook.SetFunc(IsInPVS);
+
+#ifdef _WIN32
+		const char *vscriptModuleName = "vscript.dll";
+#else
+		const char *vscriptModuleName = "vscript.so";
+#endif
+
+		auto vscriptCompileScript = Memory::Absolute<uintptr_t>(vscriptModuleName, Offsets::VScript_CompileScript);
+		if (vscriptCompileScript) {
+			VScript_CompileScript = reinterpret_cast<_VScript_CompileScript>(vscriptCompileScript);
+			g_VScriptCompileScriptHook.SetFunc(VScript_CompileScript);
+		} else {
+			console->Warning("[sar] failed to find VScript_CompileScript at offset 0x%X\n", Offsets::VScript_CompileScript);
+		}
 	}
 
 	NetMessage::RegisterHandler(RESET_COOP_PROGRESS_MESSAGE_TYPE, &netResetCoopProgress);

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -359,7 +359,7 @@ static void RecordRuntimeVscriptChecksum(const char *scriptName, const char *scr
 		sum = lodepng_crc32(reinterpret_cast<const unsigned char *>(scriptData), scriptLen);
 	}
 
-	if (engine->demorecorder->isRecordingDemo) {
+	if (engine->demorecorder->isRecordingDemo && engine->demorecorder->GetTick() >= 0) {
 		size_t nameLen = strlen(scriptName);
 		size_t bufLen = nameLen + 6;
 		auto *buf = new uint8_t[bufLen];

--- a/src/Modules/Server.cpp
+++ b/src/Modules/Server.cpp
@@ -41,7 +41,6 @@
 #include "Offsets.hpp"
 #include "Utils.hpp"
 #include "Variable.hpp"
-#include "Utils/lodepng.hpp"
 
 #include "Features/OverlayRender.hpp"
 
@@ -337,70 +336,6 @@ static bool FindClosestPassableSpace_Detour(void *entity, const Vector &ind_push
 Hook FindClosestPassableSpace_Hook(&FindClosestPassableSpace_Detour);
 
 static int (*UTIL_GetCommandClientIndex)();
-static constexpr uint8_t SAR_MSG_VSCRIPT_RUNTIME_CHECKSUM = 0x14;
-
-static size_t BoundedCStringLen(const char *str, size_t maxLen) {
-	if (!str) return 0;
-	size_t len = 0;
-	while (len < maxLen && str[len]) ++len;
-	return len;
-}
-
-static void RecordRuntimeVscriptChecksum(const char *scriptName, const char *scriptData) {
-	if (!scriptName || !*scriptName || !scriptData || !*scriptData) return;
-
-	// Meant to avoid an unbounded C-String search in case a file data ever isn't null-terminated
-	constexpr size_t MAX_SCRIPT_SIZE = 8 * 1024 * 1024;
-	size_t scriptLen = BoundedCStringLen(scriptData, MAX_SCRIPT_SIZE);
-	if (scriptLen == 0) return;
-
-	uint32_t sum = 0;
-	if (scriptLen < MAX_SCRIPT_SIZE) {
-		sum = lodepng_crc32(reinterpret_cast<const unsigned char *>(scriptData), scriptLen);
-	}
-
-	if (engine->demorecorder->isRecordingDemo && engine->demorecorder->GetTick() >= 0) {
-		size_t nameLen = strlen(scriptName);
-		size_t bufLen = nameLen + 6;
-		auto *buf = new uint8_t[bufLen];
-		buf[0] = SAR_MSG_VSCRIPT_RUNTIME_CHECKSUM;
-		*reinterpret_cast<uint32_t *>(buf + 1) = sum;
-		strcpy(reinterpret_cast<char *>(buf + 5), scriptName);
-		engine->demorecorder->RecordData(buf, bufLen);
-		delete[] buf;
-	} else {
-		engine->demorecorder->queuedVScriptChecksums.emplace_back(scriptName, sum);
-	}
-}
-
-#ifdef _WIN32
-using _VScript_CompileScript = int(__rescall *)(void *thisptr, const char *scriptData, const char *scriptName);
-#else
-using _VScript_CompileScript = int(__cdecl *)(void *thisptr, const char *scriptData, const char *scriptName);
-#endif
-static _VScript_CompileScript VScript_CompileScript;
-extern Hook g_VScriptCompileScriptHook;
-#ifdef _WIN32
-static int __fastcall VScript_CompileScript_Hook(void *thisptr, int edx, const char *scriptData, const char *scriptName)
-#else
-static int __cdecl VScript_CompileScript_Hook(void *thisptr, const char *scriptData, const char *scriptName)
-#endif
-{
-#ifdef _WIN32
-	(void)edx;
-#endif
-	(void)thisptr;
-
-	if (scriptName && *scriptName) {
-		RecordRuntimeVscriptChecksum(scriptName, scriptData);
-	}
-
-	g_VScriptCompileScriptHook.Disable();
-	auto ret = VScript_CompileScript(thisptr, scriptData, scriptName);
-	g_VScriptCompileScriptHook.Enable();
-	return ret;
-}
-Hook g_VScriptCompileScriptHook(&VScript_CompileScript_Hook);
 
 extern Hook g_ViewPunch_Hook;
 DETOUR_T(void, Server::ViewPunch, const QAngle &offset) {
@@ -1034,20 +969,6 @@ bool Server::Init() {
 	if (sar.game->Is(SourceGame_Portal2 | SourceGame_Portal2_2011)) {
 		Server::IsInPVS = (Server::_IsInPVS)Memory::Scan(this->Name(), Offsets::IsInPVS);
 		g_IsInPVS_Hook.SetFunc(IsInPVS);
-
-#ifdef _WIN32
-		const char *vscriptModuleName = "vscript.dll";
-#else
-		const char *vscriptModuleName = "vscript.so";
-#endif
-
-		auto vscriptCompileScript = Memory::Absolute<uintptr_t>(vscriptModuleName, Offsets::VScript_CompileScript);
-		if (vscriptCompileScript) {
-			VScript_CompileScript = reinterpret_cast<_VScript_CompileScript>(vscriptCompileScript);
-			g_VScriptCompileScriptHook.SetFunc(VScript_CompileScript);
-		} else {
-			console->Warning("[sar] failed to find VScript_CompileScript at offset 0x%X\n", Offsets::VScript_CompileScript);
-		}
 	}
 
 	NetMessage::RegisterHandler(RESET_COOP_PROGRESS_MESSAGE_TYPE, &netResetCoopProgress);

--- a/src/Modules/VScript.cpp
+++ b/src/Modules/VScript.cpp
@@ -1,0 +1,38 @@
+#include "VScript.hpp"
+
+#include "Checksum.hpp"
+#include "Game.hpp"
+#include "Hook.hpp"
+#include "Offsets.hpp"
+#include "SAR.hpp"
+
+REDECL(VScript::CompileScript);
+
+extern Hook g_VScriptCompileScriptHook;
+DETOUR_T(int, VScript::CompileScript, const char *scriptData, const char *scriptName) {
+	if (scriptName && *scriptName) {
+		RecordRuntimeVscriptChecksum(scriptName, scriptData);
+	}
+
+	g_VScriptCompileScriptHook.Disable();
+	auto ret = VScript::CompileScript(thisptr, scriptData, scriptName);
+	g_VScriptCompileScriptHook.Enable();
+	return ret;
+}
+Hook g_VScriptCompileScriptHook(&VScript::CompileScript_Hook);
+
+bool VScript::Init() {
+	VScript::CompileScript = (VScript::_CompileScript)Memory::Scan(this->Name(), Offsets::VScript_CompileScript);
+	if (!VScript::CompileScript) {
+		console->Warning("[sar] failed to find VScript_CompileScript\n");
+		return false;
+	}
+
+	g_VScriptCompileScriptHook.SetFunc(VScript::CompileScript);
+	return this->hasLoaded = true;
+}
+
+void VScript::Shutdown() {
+}
+
+VScript *vscript;

--- a/src/Modules/VScript.cpp
+++ b/src/Modules/VScript.cpp
@@ -24,7 +24,6 @@ Hook g_VScriptCompileScriptHook(&VScript::CompileScript_Hook);
 bool VScript::Init() {
 	VScript::CompileScript = (VScript::_CompileScript)Memory::Scan(this->Name(), Offsets::VScript_CompileScript);
 	if (!VScript::CompileScript) {
-		console->Warning("[sar] failed to find VScript_CompileScript\n");
 		return false;
 	}
 

--- a/src/Modules/VScript.hpp
+++ b/src/Modules/VScript.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Module.hpp"
+#include "Utils.hpp"
+
+class VScript : public Module {
+public:
+	// CVScriptGameSystem::CompileScript
+	DECL_DETOUR_T(int, CompileScript, const char *scriptData, const char *scriptName);
+
+	bool Init() override;
+	void Shutdown() override;
+	const char *Name() override { return MODULE("vscript"); }
+};
+
+extern VScript *vscript;

--- a/src/Offsets/Beginners Guide 6167.hpp
+++ b/src/Offsets/Beginners Guide 6167.hpp
@@ -115,4 +115,7 @@ SIGSCAN_LINUX(UpdateLeaderboardData, "")
 SIGSCAN_WINDOWS(interfaceMgrSig, "83 3D ? ? ? ? 00 74 ? B0 01")
 OFFSET_WINDOWS(interfaceMgrOff, 2)
 
+// VScript
+SIGSCAN_LINUX(VScript_CompileScript, "55 89 E5 83 EC 38 89 5D ? 8B 5D ? 89 7D ? 31 FF 89 75 ? 8B 75")
+
 // clang-format on

--- a/src/Offsets/Portal 2 5723.hpp
+++ b/src/Offsets/Portal 2 5723.hpp
@@ -30,3 +30,16 @@ OFFSET_LINUX(DrawPortalSpBranchOff, 0x15)
 SIGSCAN_LINUX(DrawPortalGhost, "55 89 E5 57 56 53 83 EC 5C A1 ? ? ? ? 8B 40")
 SIGSCAN_LINUX(DrawPortalGhostSpBranch, "0F 84 ? ? ? ? FF 90 ? ? ? ? 80 BB ? ? ? ? 01")
 SIGSCAN_LINUX(GetChapterProgress, "55 89 E5 57 56 53 83 EC 2C 8B 7D 08 E8 ? ? ? ? 8B 10 C7")
+SIGSCAN_LINUX(DispatchParticleEffect,"")
+SIGSCAN_LINUX(PrecacheParticleSystem, "")
+SIGSCAN_LINUX(GetCurrentTonemappingSystem, "")
+SIGSCAN_LINUX(ResetToneMapping, "")
+SIGSCAN_LINUX(LoadingProgress__SetupControlStatesInstruction, "")
+
+//Server
+SIGSCAN_LINUX(FloorReportalBranch,"")
+SIGSCAN_LINUX(CPortal_Player__PollForUseEntity_CheckMP, "")
+
+//VScript
+SIGSCAN_LINUX(VScript_CompileScript, "55 89 E5 83 EC 38 89 5D F4 8B 5D 0C 89 7D FC 31 FF 89 75 F8 8B 75 10 85 DB 0F 84 ? ? ? ? 80 3B 00 0F 84 ? ? ? ? 85 F6 B8 ? ? ? ? 89")
+

--- a/src/Offsets/Portal 2 5723.hpp
+++ b/src/Offsets/Portal 2 5723.hpp
@@ -30,6 +30,10 @@ OFFSET_LINUX(DrawPortalSpBranchOff, 0x15)
 SIGSCAN_LINUX(DrawPortalGhost, "55 89 E5 57 56 53 83 EC 5C A1 ? ? ? ? 8B 40")
 SIGSCAN_LINUX(DrawPortalGhostSpBranch, "0F 84 ? ? ? ? FF 90 ? ? ? ? 80 BB ? ? ? ? 01")
 SIGSCAN_LINUX(GetChapterProgress, "55 89 E5 57 56 53 83 EC 2C 8B 7D 08 E8 ? ? ? ? 8B 10 C7")
+SIGSCAN_LINUX(DispatchParticleEffect, "55 89 E5 83 EC ? 8B 45 ? 89 5D ? 89 75 ? 8B 5D ? 8B 75 ? 89 7D ? 8B 7D ? 89 04 24")
+SIGSCAN_LINUX(PrecacheParticleSystem, "55 89 E5 83 EC ? A1 ? ? ? ? 89 5D ? 89 75 ? 8B 5D ? 8B 10 C7 44 24 ? ? ? ? ? 89 5C 24")
+SIGSCAN_LINUX(GetCurrentTonemappingSystem, "55 89 E5 53 83 EC ? 80 3D ? ? ? ? ? 0F 85")
+SIGSCAN_LINUX(ResetToneMapping, "55 89 E5 53 83 EC ? 8B 5D ? E8 ? ? ? ? 89 04 24 89 5C 24")
 
 // Server
 SIGSCAN_LINUX(FloorReportalBranch,"75 ? 8B 83 ? ? ? ? 8B 0D ? ? ? ? 83 F8 FF 74 ? 0F B7 D0 C1 E8 10 8D 14 ? 8D 14 ? 39 42 ? 75 ? 8B 42 ? 85 C0 74 ? 89 04 24 E8 ? ? ? ? 8B 85")

--- a/src/Offsets/Portal 2 5723.hpp
+++ b/src/Offsets/Portal 2 5723.hpp
@@ -32,7 +32,7 @@ SIGSCAN_LINUX(DrawPortalGhostSpBranch, "0F 84 ? ? ? ? FF 90 ? ? ? ? 80 BB ? ? ? 
 SIGSCAN_LINUX(GetChapterProgress, "55 89 E5 57 56 53 83 EC 2C 8B 7D 08 E8 ? ? ? ? 8B 10 C7")
 
 // Server
-SIGSCAN_LINUX(FloorReportalBranch,"")
+SIGSCAN_LINUX(FloorReportalBranch,"75 ? 8B 83 ? ? ? ? 8B 0D ? ? ? ? 83 F8 FF 74 ? 0F B7 D0 C1 E8 10 8D 14 ? 8D 14 ? 39 42 ? 75 ? 8B 42 ? 85 C0 74 ? 89 04 24 E8 ? ? ? ? 8B 85")
 
 // VScript
 SIGSCAN_LINUX(VScript_CompileScript, "55 89 E5 83 EC 38 89 5D F4 8B 5D 0C 89 7D FC 31 FF 89 75 F8 8B 75 10 85 DB 0F 84 ? ? ? ? 80 3B 00 0F 84 ? ? ? ? 85 F6 B8 ? ? ? ? 89")

--- a/src/Offsets/Portal 2 5723.hpp
+++ b/src/Offsets/Portal 2 5723.hpp
@@ -30,16 +30,9 @@ OFFSET_LINUX(DrawPortalSpBranchOff, 0x15)
 SIGSCAN_LINUX(DrawPortalGhost, "55 89 E5 57 56 53 83 EC 5C A1 ? ? ? ? 8B 40")
 SIGSCAN_LINUX(DrawPortalGhostSpBranch, "0F 84 ? ? ? ? FF 90 ? ? ? ? 80 BB ? ? ? ? 01")
 SIGSCAN_LINUX(GetChapterProgress, "55 89 E5 57 56 53 83 EC 2C 8B 7D 08 E8 ? ? ? ? 8B 10 C7")
-SIGSCAN_LINUX(DispatchParticleEffect,"")
-SIGSCAN_LINUX(PrecacheParticleSystem, "")
-SIGSCAN_LINUX(GetCurrentTonemappingSystem, "")
-SIGSCAN_LINUX(ResetToneMapping, "")
-SIGSCAN_LINUX(LoadingProgress__SetupControlStatesInstruction, "")
 
-//Server
+// Server
 SIGSCAN_LINUX(FloorReportalBranch,"")
-SIGSCAN_LINUX(CPortal_Player__PollForUseEntity_CheckMP, "")
 
-//VScript
+// VScript
 SIGSCAN_LINUX(VScript_CompileScript, "55 89 E5 83 EC 38 89 5D F4 8B 5D 0C 89 7D FC 31 FF 89 75 F8 8B 75 10 85 DB 0F 84 ? ? ? ? 80 3B 00 0F 84 ? ? ? ? 85 F6 B8 ? ? ? ? 89")
-

--- a/src/Offsets/Portal 2 8151.hpp
+++ b/src/Offsets/Portal 2 8151.hpp
@@ -107,7 +107,7 @@ SIGSCAN_DEFAULT(Portal2PromoFlagsSig, "", "")
 SIGSCAN_LINUX(FloorReportalBranch, "")
 SIGSCAN_LINUX(CPortal_Player__PollForUseEntity_CheckMP, "")
 
-//VScript
+// VScript
 SIGSCAN_LINUX(VScript_CompileScript, "55 89 E5 57 56 53 83 EC 2C 8B 5D 0C 8B 75 08 8B 45 10 85 DB 0F 84 ? ? ? ? 80 3B 00 0F 84 ? ? ? ? 85 C0 BF ? ? ? ? 89 1C 24 0F 45 F8")
 
 // clang-format on

--- a/src/Offsets/Portal 2 8151.hpp
+++ b/src/Offsets/Portal 2 8151.hpp
@@ -68,10 +68,10 @@ SIGSCAN_LINUX(AddShadowToReceiver, "55 89 E5 57 56 53 83 EC ? 8B 45 ? 8B 4D ? 8B
 SIGSCAN_LINUX(UTIL_Portal_Color, "55 89 E5 56 53 83 EC 10 8B 75 ? 8B 5D ? 85 F6 0F 84")
 SIGSCAN_LINUX(UTIL_Portal_Color_Particles, "55 89 E5 53 83 EC 14 A1 ? ? ? ? 8B 5D ? 8B 10 89 04 24 FF 92 ? ? ? ? 84 C0 75 ? 83 7D ? 01")
 SIGSCAN_LINUX(GetChapterProgress, "55 89 E5 57 56 53 83 EC 2C 8B 5D 08 E8 ? ? ? ? 8B 10")
-SIGSCAN_LINUX(DispatchParticleEffect, "")
-SIGSCAN_LINUX(PrecacheParticleSystem, "")
-SIGSCAN_LINUX(GetCurrentTonemappingSystem, "")
-SIGSCAN_LINUX(ResetToneMapping, "")
+SIGSCAN_LINUX(DispatchParticleEffect, "55 89 E5 57 56 31 F6 53 81 EC BC 00 00 00 8B 5D")
+SIGSCAN_LINUX(PrecacheParticleSystem, "55 89 E5 56 53 83 EC 20 A1 ? ? ? ? 8B 5D ? 8B 10 C7 44 24 ? 00 00 00 00")
+SIGSCAN_LINUX(GetCurrentTonemappingSystem, "55 89 E5 53 83 EC 14 80 3D ? ? ? ? 00 0F 85")
+SIGSCAN_LINUX(ResetToneMapping, "55 89 E5 57 56 53 83 EC 3C 8B 15 ? ? ? ? 8B 5D ? 8B 42")
 SIGSCAN_LINUX(LoadingProgress__SetupControlStatesInstruction, "")
 
 // Engine
@@ -104,7 +104,7 @@ SIGSCAN_LINUX(CheckStuck_FloatTime, "E8 ? ? ? ? 8B 43 04 DD 9D ? ? ? ? F2 0F 10 
 SIGSCAN_DEFAULT(aircontrol_fling_speedSig, "0F 2F 25 ? ? ? ? 0F 28 F0",
                                            "0F 2E 05 ? ? ? ? 0F 86 ? ? ? ? 0F 2E 25")
 SIGSCAN_DEFAULT(Portal2PromoFlagsSig, "", "")
-SIGSCAN_LINUX(FloorReportalBranch, "")
+SIGSCAN_LINUX(FloorReportalBranch, "75 ? 8B 87 ? ? ? ? 8B 15")
 SIGSCAN_LINUX(CPortal_Player__PollForUseEntity_CheckMP, "")
 
 // VScript

--- a/src/Offsets/Portal 2 8151.hpp
+++ b/src/Offsets/Portal 2 8151.hpp
@@ -68,6 +68,11 @@ SIGSCAN_LINUX(AddShadowToReceiver, "55 89 E5 57 56 53 83 EC ? 8B 45 ? 8B 4D ? 8B
 SIGSCAN_LINUX(UTIL_Portal_Color, "55 89 E5 56 53 83 EC 10 8B 75 ? 8B 5D ? 85 F6 0F 84")
 SIGSCAN_LINUX(UTIL_Portal_Color_Particles, "55 89 E5 53 83 EC 14 A1 ? ? ? ? 8B 5D ? 8B 10 89 04 24 FF 92 ? ? ? ? 84 C0 75 ? 83 7D ? 01")
 SIGSCAN_LINUX(GetChapterProgress, "55 89 E5 57 56 53 83 EC 2C 8B 5D 08 E8 ? ? ? ? 8B 10")
+SIGSCAN_LINUX(DispatchParticleEffect, "")
+SIGSCAN_LINUX(PrecacheParticleSystem, "")
+SIGSCAN_LINUX(GetCurrentTonemappingSystem, "")
+SIGSCAN_LINUX(ResetToneMapping, "")
+SIGSCAN_LINUX(LoadingProgress__SetupControlStatesInstruction, "")
 
 // Engine
 SIGSCAN_LINUX(Host_AccumulateTime, "55 89 E5 83 EC 28 F3 0F 10 05 ? ? ? ? A1 ? ? ? ? F3 0F 58 45 08 F3 0F 11 05 ? ? ? ? 8B 10 89 04 24 FF 52 24")
@@ -98,5 +103,11 @@ SIGSCAN_LINUX(UTIL_GetCommandClientIndex, "A1 ? ? ? ? 55 89 E5 5D 83 C0 01 C3")
 SIGSCAN_LINUX(CheckStuck_FloatTime, "E8 ? ? ? ? 8B 43 04 DD 9D ? ? ? ? F2 0F 10 B5 ? ? ? ? 8B 50 24 66 0F 14 F6 66 0F 5A CE 85 D2")
 SIGSCAN_DEFAULT(aircontrol_fling_speedSig, "0F 2F 25 ? ? ? ? 0F 28 F0",
                                            "0F 2E 05 ? ? ? ? 0F 86 ? ? ? ? 0F 2E 25")
+SIGSCAN_DEFAULT(Portal2PromoFlagsSig, "", "")
+SIGSCAN_LINUX(FloorReportalBranch, "")
+SIGSCAN_LINUX(CPortal_Player__PollForUseEntity_CheckMP, "")
+
+//VScript
+SIGSCAN_LINUX(VScript_CompileScript, "55 89 E5 57 56 53 83 EC 2C 8B 5D 0C 8B 75 08 8B 45 10 85 DB 0F 84 ? ? ? ? 80 3B 00 0F 84 ? ? ? ? 85 C0 BF ? ? ? ? 89 1C 24 0F 45 F8")
 
 // clang-format on

--- a/src/Offsets/Portal 2 9568.hpp
+++ b/src/Offsets/Portal 2 9568.hpp
@@ -295,6 +295,7 @@ OFFSET_DEFAULT(GetModel, 8, 8)
 // Others
 OFFSET_DEFAULT(tickcount, 95, 64)
 OFFSET_DEFAULT(interval_per_tick, 65, 58)
+OFFSET_DEFAULT(VScript_CompileScript, 0x28B50, 0x615D0)
 OFFSET_DEFAULT(GetClientStateFunction, 4, 9)
 OFFSET_EMPTY(cl)
 OFFSET_DEFAULT(demoplayer, 74, 80)

--- a/src/Offsets/Portal 2 9568.hpp
+++ b/src/Offsets/Portal 2 9568.hpp
@@ -545,8 +545,9 @@ OFFSET_DEFAULT(Portal2PromoFlagsOff, 2, 1)
 OFFSET_EMPTY(DestroyEnvironment)
 OFFSET_EMPTY(GetActiveEnvironmentByIndex)
 
-// Vscript
-SIGSCAN_DEFAULT(VScript_CompileScript, "55 8B EC 83 EC 0C 56 57 8B 7D 08 8B F1 85 FF 0F 84 ? ? ? ? 80 3F 00 0F 84 ? ? ? ? 53 8B", "57 56 53 8B 5C 24 14 8B 7C 24 10 8B 74 24 18 85 DB 74 ? 80 3B 00 74 ? 85 F6 B8 ? ? ? ? 0F 44 F0 83 EC 0C 53 E8 ? ? ? ? C7 04 24 01 00")
+// VScript
+SIGSCAN_DEFAULT(VScript_CompileScript, "55 8B EC 83 EC 0C 56 57 8B 7D 08 8B F1 85 FF 0F 84 ? ? ? ? 80 3F 00 0F 84 ? ? ? ? 53 8B",
+                                       "57 56 53 8B 5C 24 14 8B 7C 24 10 8B 74 24 18 85 DB 74 ? 80 3B 00 74 ? 85 F6 B8 ? ? ? ? 0F 44 F0 83 EC 0C 53 E8 ? ? ? ? C7 04 24 01 00") // "unnamed" xref -> function with two references -> CScriptVM::CompileScript
 
 
 // Steam API

--- a/src/Offsets/Portal 2 9568.hpp
+++ b/src/Offsets/Portal 2 9568.hpp
@@ -295,7 +295,6 @@ OFFSET_DEFAULT(GetModel, 8, 8)
 // Others
 OFFSET_DEFAULT(tickcount, 95, 64)
 OFFSET_DEFAULT(interval_per_tick, 65, 58)
-OFFSET_DEFAULT(VScript_CompileScript, 0x28B50, 0x615D0)
 OFFSET_DEFAULT(GetClientStateFunction, 4, 9)
 OFFSET_EMPTY(cl)
 OFFSET_DEFAULT(demoplayer, 74, 80)
@@ -545,6 +544,9 @@ OFFSET_DEFAULT(Portal2PromoFlagsOff, 2, 1)
 // VPhysics
 OFFSET_EMPTY(DestroyEnvironment)
 OFFSET_EMPTY(GetActiveEnvironmentByIndex)
+
+// Vscript
+SIGSCAN_DEFAULT(VScript_CompileScript, "55 8B EC 83 EC 0C 56 57 8B 7D 08 8B F1 85 FF 0F 84 ? ? ? ? 80 3F 00 0F 84 ? ? ? ? 53 8B", "57 56 53 8B 5C 24 14 8B 7C 24 10 8B 74 24 18 85 DB 74 ? 80 3B 00 74 ? 85 F6 B8 ? ? ? ? 0F 44 F0 83 EC 0C 53 E8 ? ? ? ? C7 04 24 01 00")
 
 
 // Steam API

--- a/src/SAR.cpp
+++ b/src/SAR.cpp
@@ -101,6 +101,7 @@ bool SAR::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceFn gameServerF
 			this->modules->AddModule<Matchmaking>(&matchmaking);
 			this->modules->AddModule<SteamAPI>(&steam);
 			this->modules->AddModule<VPhysics>(&vphysics);
+			this->modules->AddModule<VScript>(&vscript);
 			this->modules->InitAll();
 
 			SarInitHandler::RunAll();


### PR DESCRIPTION
### Issue / Solution
This is fixing the issue of SAR only calculating vscript checksums when the plugin is loaded.

This adds a secondary check to the vscript compile execution path. It records the script name, and a checksum of the runtime script buffer to demos.

### Notes
- Tested and working on Linux (Ubuntu 22.xx)
- The runtime script buffer checksums do align with the filechecksums from the game
- Queue's the vscripts executed during map load (similar to queued commands)
- Added as a new data type in case we want to treat this differently than regular file sums. 
- Upcoming mdp PR will have a config option to not show the new vscript data (it'll be spammy for a while until we filter them)

### Testing
I only tested a chapter run and a single demo (on linux and windows).  For the single demo I started the demo a bit into the level to ensure the queuing was working correctly. I'll attach the mdp output to the PR in case anyone wants to have a look. 
[output.txt](https://github.com/user-attachments/files/27241338/output.txt)
