### PR TITLE
Updated vpk whitelist for version 10090

### DIFF
--- a/src/Checksum.cpp
+++ b/src/Checksum.cpp
@@ -238,7 +238,11 @@ static std::thread g_sumthreads[NUM_FILE_SUM_THREADS];
 static std::map<std::string, uint32_t> g_filesums[NUM_FILE_SUM_THREADS];
 
 static const uint32_t g_vpkWhitelist[] = {
-	// Portal 2
+	// Portal 2 (10090)
+	1937334792,	// portal2/pak01_dir.vpk
+	525202717,	// portal2_dlc1/pak01_dir.vpk
+	1882863719,	// portal2_dlc2/pak01_dir.vpk
+	// Portal 2 (9568)
 	4107509135, // /portal2/pak01_dir.vpk
 	2990582453,	// /portal2_german/pak01_dir.vpk
 	2395721311, // /portal2_french/pak01_dir.vpk


### PR DESCRIPTION
Language localizations didn't have any updates.
update folder surprisingly didn't change either, it was just the base + DLCs.